### PR TITLE
plugging through database import issues

### DIFF
--- a/chicago/__init__.py
+++ b/chicago/__init__.py
@@ -7,8 +7,8 @@ from .bills import ChicagoBillScraper
 
 class Chicago(Jurisdiction):
     division_id = 'ocd-division/country:us/state:il/place:chicago'
-    classification='legislature'
-    name = 'Chicago'
+    classification='government'
+    name = 'Chicago City Government'
     url =  'https://chicago.legistar.com/'
     parties = [ {'name': 'Democrats' } ]
 

--- a/chicago/__init__.py
+++ b/chicago/__init__.py
@@ -7,7 +7,7 @@ from .bills import ChicagoBillScraper
 
 class Chicago(Jurisdiction):
     division_id = 'ocd-division/country:us/state:il/place:chicago'
-    classification='council'
+    classification='legislature'
     name = 'Chicago City Council'
     url =  'https://chicago.legistar.com/'
     parties = [ {'name': 'Democrats' } ]

--- a/chicago/__init__.py
+++ b/chicago/__init__.py
@@ -8,7 +8,7 @@ from .bills import ChicagoBillScraper
 class Chicago(Jurisdiction):
     division_id = 'ocd-division/country:us/state:il/place:chicago'
     classification='legislature'
-    name = 'Chicago City Council'
+    name = 'Chicago'
     url =  'https://chicago.legistar.com/'
     parties = [ {'name': 'Democrats' } ]
 
@@ -35,16 +35,13 @@ class Chicago(Jurisdiction):
     def get_organizations(self):
         org = Organization(name="Chicago City Council", classification="legislature")
 
-        org.add_post("Clerk", "Clerk",
-             division_id="ocd-division/country:us/state:il/place:chicago")
+        org.add_post("Clerk", "Clerk")
 
-        org.add_post("Mayor", "Mayor",
-             division_id="ocd-division/country:us/state:il/place:chicago")
+        org.add_post("Mayor", "Mayor")
 
         for x in range(1, 51):
             org.add_post(
                 "Ward {}".format(x),
-                "Alderman",
-                division_id="ocd-division/country:us/state:il/place:chicago"
-            )
+                "Alderman")
+
         yield org

--- a/chicago/bills.py
+++ b/chicago/bills.py
@@ -113,7 +113,7 @@ class ChicagoBillScraper(LegistarScraper):
                             legislative_session=bill_session,
                             title=title,
                             classification=bill_type,
-                            from_organization=self.jurisdiction.name)
+                            from_organization={"name":"Chicago City Council"})
 
                 bill.add_source(legislation_summary['url'])
 
@@ -160,10 +160,11 @@ class ChicagoBillScraper(LegistarScraper):
                 continue
 
             if action_description :
-                bill.add_action(action_description,
+                act = bill.add_action(action_description,
                                 action_date,
-                                organization=action['Action\xa0By'],
                                 classification=ACTION_CLASSIFICATION[action_description])
+                act.add_related_entity(action['Action\xa0By']['label'],
+                                      entity_type="organization")
                 if 'url' in action['Action\xa0Details'] :
                     action_detail_url = action['Action\xa0Details']['url']
                     result, votes = self.extractVotes(action_detail_url)
@@ -174,7 +175,7 @@ class ChicagoBillScraper(LegistarScraper):
                                            classification=None,
                                            start_date=action_date,
                                            result=result,
-                                           bill=bill.identifier)
+                                           bill=bill)
                         action_vote.add_source(action_detail_url)
                         for option, voter in votes :
                             action_vote.vote(option, voter)

--- a/chicago/events.py
+++ b/chicago/events.py
@@ -72,7 +72,7 @@ class ChicagoEventsScraper(LegistarScraper):
                                           'rescheduled indefinitely',
                                           'rescheduled for')) :
                         status = 'cancelled'
-                    elif status_text in ('rescheduled') :
+                    elif status_text in ('rescheduled', "changing time") :
                         status = 'cancelled'
                     else :
                         print(status_text)

--- a/chicago/events.py
+++ b/chicago/events.py
@@ -47,7 +47,7 @@ class ChicagoEventsScraper(LegistarScraper):
                     meeting_details = False
                     
                 location_string = events[u'Meeting\xa0Location']
-                location_list = location_string.split('--')
+                location_list = location_string.split('--', 2)
                 location = ', '.join(location_list[0:2])
                 if not location :
                     continue
@@ -62,7 +62,13 @@ class ChicagoEventsScraper(LegistarScraper):
                 status_string = location_list[-1].split('Chicago, Illinois')
                 if len(status_string) > 1 and status_string[1] :
                     status_text = status_string[1].lower()
-                    if any(phrase in status_text 
+                    print(status_text)
+                    if any(phrase in status_text
+                            for phrase in ('public hearing',
+                                            'budget hearing',
+                                            'special meeting')):
+                        continue
+                    elif any(phrase in status_text 
                            for phrase in ('rescheduled to',
                                           'postponed to',
                                           'reconvened to',
@@ -70,12 +76,16 @@ class ChicagoEventsScraper(LegistarScraper):
                                           'cancelled',
                                           'new date and time',
                                           'rescheduled indefinitely',
-                                          'rescheduled for')) :
+                                          'rescheduled for',
+                                          'changing time',)) :
                         status = 'cancelled'
-                    elif status_text in ('rescheduled', "changing time") :
+                    elif status_text in ('rescheduled') :
                         status = 'cancelled'
                     else :
                         print(status_text)
+                        #we are skipping these for now because
+                        #they are almost all duplictes.
+                        continue
                 elif datetime.datetime.utcnow().replace(tzinfo = pytz.utc) > when :
                     status = 'confirmed'
                 else :

--- a/chicago/legistar.py
+++ b/chicago/legistar.py
@@ -30,7 +30,8 @@ class LegistarScraper(Scraper):
         yield page
 
         next_page = page.xpath("//a[@class='rgCurrentPage']/following-sibling::a[1]")
-        del payload['ctl00$ContentPlaceHolder1$btnSearch']
+        if payload and 'ctl00$ContentPlaceHolder1$btnSearch' in payload:
+            del payload['ctl00$ContentPlaceHolder1$btnSearch']
 
         while len(next_page) > 0 :
             

--- a/chicago/people.py
+++ b/chicago/people.py
@@ -50,10 +50,13 @@ class ChicagoPersonScraper(LegistarScraper):
                 "Clerk",
             ]:
                 ward = "Ward {}".format(int(ward))
-
+                role = "Alderman"
+            else:
+                role = ward
             p = Person(councilman['Person Name']['label'],
                        district=ward,
-                       primary_org="legislature")
+                       primary_org="legislature",
+                       role=role)
 
             if councilman['Photo'] :
                 p.image = councilman['Photo']


### PR DESCRIPTION
NOT ACTUALLY READY TO GO, want to run a bunch of stuff past @fgregg 

1) this was failing locally for me on the changes you made to the legistar scraper. I'll comment directly on that line. Can you check it and make sure my changes don't hurt anything?

2) I'm having trouble with duplicate events during the database import phase. In some cases it looked like event rescheduling notices, so I added some more possible rescheduling text, but it's also pulling things like this, which all seem to be the same event.
https://chicago.legistar.com/MeetingDetail.aspx?ID=184426&GUID=0FB72168-5E0C-4F42-B782-E79DCCC1B9B6&Options=info|
https://chicago.legistar.com/MeetingDetail.aspx?ID=190991&GUID=14BD8DD5-4C57-4A11-AA09-D124C9551DB0&Options=info|
https://chicago.legistar.com/MeetingDetail.aspx?ID=191000&GUID=F46D8B14-13E1-4500-A47D-428604931403&Options=info|

How should we deal with those? Our system thinks they're duplicates, so won't successfully import.

I'm running bills now locally to see if there are any remaining import issues there, if I can get it to finish on my local.
