### PR TITLE
Add a new action to chicago and a leg type to nyc

### DIFF
--- a/chicago/bills.py
+++ b/chicago/bills.py
@@ -271,7 +271,10 @@ ACTION = {'Direct Introduction':
           'Published in Special Pamphlet':
               {'ocd': None, 'order': 3},
           'Signed by Mayor':
-              {'ocd': 'executive-signature', 'order': 3}}
+              {'ocd': 'executive-signature', 'order': 3},
+              
+          'Repealed':
+              {'ocd': None, 'order': 4},}
       
                          
 

--- a/nyc/bills.py
+++ b/nyc/bills.py
@@ -165,7 +165,8 @@ BILL_TYPES = {'Introduction' : 'bill',
               'Town Hall Meeting' : None,
               'Tour': None, 
               'Petition': 'petition', 
-              'SLR': None}
+              'SLR': None,
+              'City Agency Report': None}
 
 
 ACTION_CLASSIFICATION = {


### PR DESCRIPTION
Add Repealed as a bill action to chicago and City Agency Report as a leg type to nyc