### PR TITLE
Update ACTION_CLASSIFICATION dict

### DIFF
--- a/nyc/bills.py
+++ b/nyc/bills.py
@@ -172,6 +172,7 @@ BILL_TYPES = {'Introduction' : 'bill',
 
 
 ACTION_CLASSIFICATION = {
+    'Recalled by Council': None,
     'Tour Held by Committee' : None,
     'Hearing on P-C Item by Comm' : None,
     'Approved by Committee with Modifications and Referred to CPC' : 'committee-passage',


### PR DESCRIPTION
@fgregg - this PR resolves https://sentry.io/datamade/ocd-scrapers/issues/336893006/

I put "None" as the value, since I do not see any existing classifications that could make sense. Does that sound okay?