### PR TITLE
Remove leading space in action classification dict

### DIFF
--- a/nyc/bills.py
+++ b/nyc/bills.py
@@ -211,7 +211,7 @@ ACTION_CLASSIFICATION = {
     'Filed by Committee with Companion Resolution' : 'filing',
     'Hearing Held by Committee' : None,
     'Approved by Committee' : 'committee-passage',
-    'P-C Item Approved by Subcommittee with Modifications and Referred to CPC' : ' committee-passage',
+    'P-C Item Approved by Subcommittee with Modifications and Referred to CPC' : 'committee-passage',
     'Approved with Modifications and Referred to the City Planning Commission pursuant to Rule 11.70(b) of the Rules of the Council and Section 197-(d) of the New York City Charter.' : None,
     'Approved by Subcommittee with Modifications and Referred pursuant to Rule 11.20(b) of the Rules of the Council and Section 197(d) of the New York City Charter' : 'committee-passage',
     'Filed, by Committee' : 'filing',


### PR DESCRIPTION
Fixes https://sentry.io/datamade/scrapers-us-municipal/issues/408938398/