### PR TITLE
Metro guid

### DIFF
--- a/lametro/events.py
+++ b/lametro/events.py
@@ -39,7 +39,11 @@ class LametroEventScraper(LegistarAPIEventScraper):
                       location_name=event["EventLocation"],
                       status=status)
 
+
             e.pupa_id = str(event['EventId'])
+
+            # Metro requires the EventGuid to build out MediaPlayer links
+            e.extras = {'Guid': event['EventGuid']}
 
             for item in self.agenda(event):
                 agenda_item = e.add_agenda_item(item["EventItemTitle"])

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -39,7 +39,6 @@ class LametroEventScraper(LegistarAPIEventScraper):
                       location_name=event["EventLocation"],
                       status=status)
 
-
             e.pupa_id = str(event['EventId'])
 
             # Metro requires the EventGuid to build out MediaPlayer links


### PR DESCRIPTION
This PR relates to [this issue for LA Metro](https://github.com/datamade/la-metro-councilmatic/issues/238). 

I placed the Guid within `extras`, since Pupa reserves the extras dict for [irregular fields](https://github.com/opencivicdata/pupa/blob/274cd0ddf9d550c5b20cd99d6d19720041d21222/ARCHITECTURE.md).