### PR TITLE
Pass Organization obj when adding memberships

### DIFF
--- a/nyc/people.py
+++ b/nyc/people.py
@@ -172,7 +172,7 @@ class NYCPersonScraper(LegistarAPIPersonScraper):
 
                         members[person] = p
 
-                    p.add_membership(body_name,
+                    p.add_membership(o,
                                      role=role,
                                      start_date=self.toDate(office['OfficeRecordStartDate']),
                                      end_date=self.toDate(office['OfficeRecordEndDate']))


### PR DESCRIPTION
Organizations of the same name, from different jurisdictions, conflict with one another on person import [if an Organization object is not passed to `add_membership`](https://github.com/opencivicdata/pupa/blob/master/pupa/scrape/popolo.py#L112). This rectifies the situation for the NYC scraper.

Resolves https://sentry.io/datamade/scrapers-us-municipal/issues/411920264/