### PR TITLE
Add one problem bill to Chicago scraper, remove two

### DIFF
--- a/chicago/bills.py
+++ b/chicago/bills.py
@@ -118,11 +118,12 @@ class ChicagoBillScraper(LegistarAPIBillScraper):
             title = matter['MatterTitle']
             identifier = matter['MatterFile']
 
-            # Temporarily, we should not scrape or import these bills: 
-            # https://chicago.legistar.com/LegislationDetail.aspx?ID=3110438&GUID=53CF438E-7246-4785-B351-2417AFBE6C6B&Options=Advanced&Search= 
-            # https://chicago.legistar.com/LegislationDetail.aspx?ID=3110435&GUID=5C6F4710-8B6F-487B-BCEF-BF8A56A3F030&Options=Advanced&Search=
-            # They have duplicate action items, which cause the entire scrape to fail. The Chicago clerk's office should fix it in the near future, after which we can remove this code.
-            problem_bills = ['A2017-78', 'A2017-79']
+            # Temporarily, we should not scrape or import these bills:
+            # https://chicago.legistar.com/LegislationDetail.aspx?ID=1008361&GUID=612DD16C-B058-4C7B-AB5E-C78AE7CC7BAB
+            # They have duplicate action items, which cause the entire scrape
+            # to fail. The Chicago clerk's office should fix it in the near
+            # future, after which we can remove this code.
+            problem_bills = ['O2011-9592']
             if identifier in problem_bills:
                 continue
 


### PR DESCRIPTION
To mine eye, it looks like the duplicate actions have been removed from our original problem events:

* https://chicago.legistar.com/LegislationDetail.aspx?ID=3110438&GUID=53CF438E-7246-4785-B351-2417AFBE6C6B&Options=Advanced&Search=
* https://chicago.legistar.com/LegislationDetail.aspx?ID=3110435&GUID=5C6F4710-8B6F-487B-BCEF-BF8A56A3F030&Options=Advanced&Search=

Meanwhile, there's a new bill with duplicate actions [causing problems](https://sentry.io/datamade/scrapers-us-municipal/issues/325748109/):

* https://chicago.legistar.com/LegislationDetail.aspx?ID=1008361&GUID=612DD16C-B058-4C7B-AB5E-C78AE7CC7BAB

This PR removes the bills that have been fixed and adds the broken one.