### PR TITLE
Fetch specified bill from NYC API

### DIFF
--- a/nyc/bills.py
+++ b/nyc/bills.py
@@ -294,9 +294,7 @@ class NYCBillScraper(LegistarAPIBillScraper):
         for matter in matters:
             bill = self.get_bill(matter)
             if bill:
-                for action in self.actions(matter['MatterId']):
-                    action, vote = action
-
+                for action, vote in self.actions(matter['MatterId']):
                     act = bill.add_action(action['action_description'],
                                           action['action_date'],
                                           organization={'name': action['responsible_org']},

--- a/nyc/bills.py
+++ b/nyc/bills.py
@@ -245,16 +245,9 @@ class NYCBillScraper(LegistarAPIBillScraper):
 
         return bill
 
-    def get_vote_event(self, bill, action):
-        '''Add action to given Bill object and make VoteEvent object,
-        if applicable.
-        '''
-        action, vote = action
-        act = bill.add_action(action['action_description'],
-                              action['action_date'],
-                              organization={'name': action['responsible_org']},
-                              classification=action['classification'])
 
+    def get_vote_event(self, bill, act, vote):
+        '''Make VoteEvent object from given Bill, action, and vote.'''
         result, votes = vote
 
         if result:
@@ -283,6 +276,9 @@ class NYCBillScraper(LegistarAPIBillScraper):
 
             return vote_event
 
+        else:
+            return None
+
 
     def scrape(self, window=3, matter_ids=None):
         self.version_errors = []
@@ -299,7 +295,14 @@ class NYCBillScraper(LegistarAPIBillScraper):
             bill = self.get_bill(matter)
             if bill:
                 for action in self.actions(matter['MatterId']):
-                    vote_event = self.get_vote_event(bill, action)
+                    action, vote = action
+
+                    act = bill.add_action(action['action_description'],
+                                          action['action_date'],
+                                          organization={'name': action['responsible_org']},
+                                          classification=action['classification'])
+
+                    vote_event = self.get_vote_event(bill, act, vote)
 
                     if vote_event:
                         yield vote_event

--- a/nyc/bills.py
+++ b/nyc/bills.py
@@ -289,6 +289,7 @@ class NYCBillScraper(LegistarAPIBillScraper):
 
         if matter_ids:
             matters = [self.fetch(matter_id) for matter_id in matter_ids.split(',')]
+            matters = filter(None, matters)  # Skip matters that are not yet in Legistar
 
         else:
             n_days_ago = datetime.datetime.utcnow() - datetime.timedelta(float(window))

--- a/nyc/bills.py
+++ b/nyc/bills.py
@@ -161,133 +161,150 @@ class NYCBillScraper(LegistarAPIBillScraper):
             yield sponsorship
 
 
-    def scrape(self, window=3):
-        if window:
-            n_days_ago = datetime.datetime.utcnow() - datetime.timedelta(float(window))
+    def format_matter(self, matter):
+        matter_id = matter['MatterId']
+        if matter_id in DUPLICATED_ACTIONS:
+            return
+
+        date = matter['MatterIntroDate']
+        title = matter['MatterName']
+        identifier = matter['MatterFile']
+
+        if not all((date, title, identifier)):
+            return
+
+        leg_type = BILL_TYPES[matter['MatterTypeName']]
+
+        bill_session = self.sessions(self.toTime(date))
+
+        bill = Bill(identifier=identifier,
+                    title=title,
+                    classification=leg_type,
+                    legislative_session=bill_session,
+                    from_organization={"name": "New York City Council"})
+
+        legistar_web = matter['legistar_url']
+        legistar_api = self.BASE_URL + '/matters/{0}'.format(matter_id)
+
+        bill.add_source(legistar_web, note='web')
+        bill.add_source(legistar_api, note='api')
+
+        if matter['MatterTitle']:
+            bill.add_title(matter['MatterTitle'])
+
+        if matter['MatterEXText5']:
+            bill.add_abstract(matter['MatterEXText5'], note='')
+
+        try:
+            for sponsorship in self.sponsorships(matter_id):
+                bill.add_sponsorship(**sponsorship)
+        except KeyError:
+            self.version_errors.append(legistar_web)
+            return
+
+        for attachment in self.attachments(matter_id):
+
+            if attachment['MatterAttachmentId'] == 103315:  # Duplicate
+                return
+
+            if attachment['MatterAttachmentName']:
+                bill.add_document_link(attachment['MatterAttachmentName'],
+                                       attachment['MatterAttachmentHyperlink'],
+                                       media_type='application/pdf')
+
+        for topic in self.topics(matter_id) :
+            bill.add_subject(topic['MatterIndexName'].strip())
+
+        for relation in self.relations(matter_id):
+            try:
+                related_bill = self.endpoint('/matters/{0}', relation['MatterRelationMatterId'])
+            except scrapelib.HTTPError:
+                return
+            else:
+                date = related_bill['MatterIntroDate']
+                related_bill_session = self.session(self.toTime(date))
+                identifier = related_bill['MatterFile']
+                bill.add_related_bill(identifier=identifier,
+                                      legislative_session=related_bill_session,
+                                      relation_type='companion')
+
+        try:
+            text = self.text(matter_id)
+        except KeyError:
+            self.version_errors.append(legistar_web)
+            return
+
+
+        if text:
+            if text['MatterTextPlain']:
+                bill.extras['plain_text'] = text['MatterTextPlain'].replace(u'\u0000', '')
+
+            if text['MatterTextRtf']:
+                bill.extras['rtf_text'] = text['MatterTextRtf'].replace(u'\u0000', '')
+
+        return bill
+
+    def format_event(self, bill, action):
+        action, vote = action
+        act = bill.add_action(action['action_description'],
+                              action['action_date'],
+                              organization={'name': action['responsible_org']},
+                              classification=action['classification'])
+
+        result, votes = vote
+
+        if result:
+            organization = json.loads(act['organization_id'].lstrip('~'))
+            vote_event = VoteEvent(legislative_session=bill.legislative_session,
+                                   motion_text=act['description'],
+                                   organization=organization,
+                                   classification=None,
+                                   start_date=act['date'],
+                                   result=result,
+                                   bill=bill)
+
+            legistar_web, legistar_api = [src['url'] for src in bill.sources]
+
+            vote_event.add_source(legistar_web)
+            vote_event.add_source(legistar_api + '/histories')
+
+            for vote in votes:
+                raw_option = vote['VoteValueName'].lower()
+
+                if raw_option == 'suspended':
+                    return
+
+                clean_option = self.VOTE_OPTIONS.get(raw_option, raw_option)
+                vote_event.vote(clean_option, vote['VotePersonName'].strip())
+
+            return vote_event
+
+
+    def scrape(self, window=3, matter_id=None):
+        self.version_errors = []
+
+        if matter_id:
+            matters = [self.fetch(matter_id)]
+
         else:
-            n_days_ago = None
+            n_days_ago = datetime.datetime.utcnow() - datetime.timedelta(float(window))
+            matters = self.matters(n_days_ago)
 
-        version_errors = []
+        for matter in matters:
+            bill = self.format_matter(matter)
+            if bill:
+                for action in self.actions(matter['MatterId']):
+                    vote_event = self.format_event(bill, action)
 
-        for matter in self.matters(n_days_ago):
-            matter_id = matter['MatterId']
-            if matter_id in DUPLICATED_ACTIONS:
-                continue
+                    if vote_event:
+                        yield vote_event
 
-            date = matter['MatterIntroDate']
-            title = matter['MatterName']
-            identifier = matter['MatterFile']
+                yield bill
 
-            if not all((date, title, identifier)):
-                continue
-
-            leg_type = BILL_TYPES[matter['MatterTypeName']]
-
-            bill_session = self.sessions(self.toTime(date))
-
-            bill = Bill(identifier=identifier,
-                        title=title,
-                        classification=leg_type,
-                        legislative_session=bill_session,
-                        from_organization={"name": "New York City Council"})
-
-            legistar_web = matter['legistar_url']
-            legistar_api = self.BASE_URL + '/matters/{0}'.format(matter_id)
-
-            bill.add_source(legistar_web, note='web')
-            bill.add_source(legistar_api, note='api')
-
-            if matter['MatterTitle']:
-                bill.add_title(matter['MatterTitle'])
-
-            if matter['MatterEXText5']:
-                bill.add_abstract(matter['MatterEXText5'], note='')
-
-            try:
-                for sponsorship in self.sponsorships(matter_id):
-                    bill.add_sponsorship(**sponsorship)
-            except KeyError:
-                version_errors.append(legistar_web)
-                continue
-
-            for attachment in self.attachments(matter_id):
-
-                if attachment['MatterAttachmentId'] == 103315:  # Duplicate
-                    continue
-
-                if attachment['MatterAttachmentName']:
-                    bill.add_document_link(attachment['MatterAttachmentName'],
-                                           attachment['MatterAttachmentHyperlink'],
-                                           media_type='application/pdf')
-
-            for topic in self.topics(matter_id) :
-                bill.add_subject(topic['MatterIndexName'].strip())
-
-            for relation in self.relations(matter_id):
-                try:
-                    related_bill = self.endpoint('/matters/{0}', relation['MatterRelationMatterId'])
-                except scrapelib.HTTPError:
-                    continue
-                else:
-                    date = related_bill['MatterIntroDate']
-                    related_bill_session = self.session(self.toTime(date))
-                    identifier = related_bill['MatterFile']
-                    bill.add_related_bill(identifier=identifier,
-                                          legislative_session=related_bill_session,
-                                          relation_type='companion')
-
-            try:
-                text = self.text(matter_id)
-            except KeyError:
-                version_errors.append(legistar_web)
-                continue
-
-
-            if text:
-                if text['MatterTextPlain']:
-                    bill.extras['plain_text'] = text['MatterTextPlain'].replace(u'\u0000', '')
-
-                if text['MatterTextRtf']:
-                    bill.extras['rtf_text'] = text['MatterTextRtf'].replace(u'\u0000', '')
-
-
-            for action, vote in self.actions(matter_id):
-                act = bill.add_action(action['action_description'],
-                                      action['action_date'],
-                                      organization={'name': action['responsible_org']},
-                                      classification=action['classification'])
-
-                result, votes = vote
-
-                if result:
-                    organization = json.loads(act['organization_id'].lstrip('~'))
-                    vote_event = VoteEvent(legislative_session=bill.legislative_session,
-                                           motion_text=act['description'],
-                                           organization=organization,
-                                           classification=None,
-                                           start_date=act['date'],
-                                           result=result,
-                                           bill=bill)
-
-                    vote_event.add_source(legistar_web)
-                    vote_event.add_source(legistar_api + '/histories')
-
-                    for vote in votes:
-                        raw_option = vote['VoteValueName'].lower()
-
-                        if raw_option == 'suspended':
-                            continue
-
-                        clean_option = self.VOTE_OPTIONS.get(raw_option, raw_option)
-                        vote_event.vote(clean_option, vote['VotePersonName'].strip())
-
-                    yield vote_event
-
-            yield bill
-
-        print('The following matters have irregular versions:')
-        for v in version_errors:
-            print(v)
+        if self.version_errors:
+            print('The following matters have irregular versions:')
+            for v in self.version_errors:
+                print(v)
 
 
 BILL_TYPES = {'Introduction': 'bill',

--- a/nyc/bills.py
+++ b/nyc/bills.py
@@ -246,8 +246,8 @@ class NYCBillScraper(LegistarAPIBillScraper):
         return bill
 
 
-    def get_vote_event(self, bill, act, vote, result):
-        '''Make VoteEvent object from given Bill, action, and vote.'''
+    def get_vote_event(self, bill, act, votes, result):
+        '''Make VoteEvent object from given Bill, action, votes and result.'''
         organization = json.loads(act['organization_id'].lstrip('~'))
         vote_event = VoteEvent(legislative_session=bill.legislative_session,
                                motion_text=act['description'],
@@ -262,7 +262,7 @@ class NYCBillScraper(LegistarAPIBillScraper):
         vote_event.add_source(legistar_web)
         vote_event.add_source(legistar_api + '/histories')
 
-        for vote in vote:
+        for vote in votes:
             raw_option = vote['VoteValueName'].lower()
 
             if raw_option == 'suspended':

--- a/nyc/bills.py
+++ b/nyc/bills.py
@@ -288,7 +288,7 @@ class NYCBillScraper(LegistarAPIBillScraper):
         self.version_errors = []
 
         if matter_ids:
-            matters = [self.fetch(matter_id) for matter_id in matter_ids.split(',')]
+            matters = [self.matter(matter_id) for matter_id in matter_ids.split(',')]
             matters = filter(None, matters)  # Skip matters that are not yet in Legistar
 
         else:


### PR DESCRIPTION
Related to https://github.com/opencivicdata/python-legistar-scraper/issues/59

Allows user to pass in `matter_id` to update a specific bill, rather than having to update all the bills in relevant time period.