### PR TITLE
get Photo from web dict to avoid KeyError in Chicago scraper

### DIFF
--- a/chicago/people.py
+++ b/chicago/people.py
@@ -45,7 +45,7 @@ class ChicagoPersonScraper(LegistarAPIPersonScraper):
                            start_date = self.toDate(term['OfficeRecordStartDate']),
                            end_date = self.toDate(term['OfficeRecordEndDate']))
 
-            if web['Photo'] :
+            if web.get('Photo'):
                 p.image = web['Photo']
 
             contact_types = {


### PR DESCRIPTION
There isn't always a photo for councilmen and women in Chicago Legistar (see: https://chicago.legistar.com/PersonDetail.aspx?ID=61032&GUID=C6D883F6-384D-4896-8EDB-522AE8247206&Search=). A photo is only added to the `web` dict by `python-legistar` [if there is a photo on the web page](https://github.com/opencivicdata/python-legistar-scraper/blob/master/legistar/people.py#L35-L38). Use `get` rather than assuming a photo will always be there.

Closes https://sentry.io/datamade/scrapers-us-municipal/issues/413541017/