### PR TITLE
Add correct alternative status

### DIFF
--- a/lametro/events.py
+++ b/lametro/events.py
@@ -36,7 +36,7 @@ class LametroEventScraper(LegistarAPIEventScraper):
             elif status_name == 'Canceled':
                 status = 'cancelled'
             else:
-                status = ''
+                status = 'tentative'
 
             e = Event(event_name,
                       start_date=event["start"],


### PR DESCRIPTION
This PR adds the appropriate status options for events. Setting `status` to an empty string throws[ a pupa validation error](https://github.com/opencivicdata/pupa/blob/a76293c4c1b17374f05f30b2b981645365d828a7/pupa/scrape/base.py#L170). Here, we can set [`status` to "tentative,"](https://github.com/opencivicdata/pupa/blob/82b5d865fd6d984fb1b9960bef9bf64da0f6b9ce/pupa/scrape/schemas/event.py#L38), if the `EventAgendaStatusName` does not have a label of "Draft," or "Final," "Canceled."
