### PR TITLE
Add new action class to NYC bill scraper

### DIFF
--- a/nyc/bills.py
+++ b/nyc/bills.py
@@ -362,6 +362,7 @@ ACTION_CLASSIFICATION = {
     'Elected to Leadership Position': None,
     'Elected to Office': None,
     'Executive Director Appointed': None,
+    'Filed (End of Session)': 'failure',
     'Filed by Committee': 'filing',
     'Filed by Committee with Companion Resolution': 'filing',
     'Filed by Council': 'filing',


### PR DESCRIPTION
There is apparently more than one way to [_sine_ a _die_](https://github.com/opencivicdata/scrapers-us-municipal/blob/b9aae1ae5257e261623cdb08b884afd62eeab7c5/nyc/bills.py#L432)!! 