### PR TITLE
Require pupa master again

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 https://github.com/opencivicdata/python-opencivicdata-django/zipball/master
-https://github.com/opencivicdata/pupa/zipball/other_names_juris
+https://github.com/opencivicdata/pupa/zipball/master
 https://github.com/opencivicdata/python-legistar-scraper/zipball/master
 lxml
 sh 


### PR DESCRIPTION
Builds are failing because the `other_names_juris` branch of `pupa` was merged and deleted. This reverts to requiring `pupa:master`.