### PR TITLE
Add correct key for City Hall address in Chicago people scraper

### DIFF
--- a/chicago/people.py
+++ b/chicago/people.py
@@ -9,8 +9,6 @@ class ChicagoPersonScraper(LegistarAPIPersonScraper):
     TIMEZONE = "America/Chicago"
 
     def scrape(self):
-        self.requests_per_minute = 0
-
         body_types = self.body_types()
 
         city_council, = [body for body in self.bodies()
@@ -24,7 +22,6 @@ class ChicagoPersonScraper(LegistarAPIPersonScraper):
         web_scraper = LegistarPersonScraper(None,None)
         web_scraper.MEMBERLIST = 'https://chicago.legistar.com/DepartmentDetail.aspx?ID=12357&GUID=4B24D5A9-FED0-4015-9154-6BFFFB2A8CB4&R=8bcbe788-98cd-4040-9086-b34fa8e49881'
         web_scraper.ALL_MEMBERS = '3:3'
-        web_scraper.requests_per_minute = 0
 
         web_info = {}
         for member, _ in web_scraper.councilMembers({'ctl00$ContentPlaceHolder$lstName' : 'City Council'}):

--- a/chicago/people.py
+++ b/chicago/people.py
@@ -59,9 +59,6 @@ class ChicagoPersonScraper(LegistarAPIPersonScraper):
                 "Fax": ("fax", "Fax")
             }
 
-            import pdb
-            pdb.set_trace()
-
             for contact_type, (type_, _note) in contact_types.items():
                 if web[contact_type] and web[contact_type] != 'N/A':
                     p.add_contact_detail(type=type_,

--- a/chicago/people.py
+++ b/chicago/people.py
@@ -9,6 +9,8 @@ class ChicagoPersonScraper(LegistarAPIPersonScraper):
     TIMEZONE = "America/Chicago"
 
     def scrape(self):
+        self.requests_per_minute = 0
+
         body_types = self.body_types()
 
         city_council, = [body for body in self.bodies()
@@ -22,6 +24,7 @@ class ChicagoPersonScraper(LegistarAPIPersonScraper):
         web_scraper = LegistarPersonScraper(None,None)
         web_scraper.MEMBERLIST = 'https://chicago.legistar.com/DepartmentDetail.aspx?ID=12357&GUID=4B24D5A9-FED0-4015-9154-6BFFFB2A8CB4&R=8bcbe788-98cd-4040-9086-b34fa8e49881'
         web_scraper.ALL_MEMBERS = '3:3'
+        web_scraper.requests_per_minute = 0
 
         web_info = {}
         for member, _ in web_scraper.councilMembers({'ctl00$ContentPlaceHolder$lstName' : 'City Council'}):
@@ -49,12 +52,15 @@ class ChicagoPersonScraper(LegistarAPIPersonScraper):
                 p.image = web['Photo']
 
             contact_types = {
-                "City Hall Office": ("address", "City Hall Office"),
+                "City Hall Address": ("address", "City Hall Address"),
                 "City Hall Phone": ("voice", "City Hall Phone"),
                 "Ward Office Phone": ("voice", "Ward Office Phone"),
                 "Ward Office Address": ("address", "Ward Office Address"),
                 "Fax": ("fax", "Fax")
             }
+
+            import pdb
+            pdb.set_trace()
 
             for contact_type, (type_, _note) in contact_types.items():
                 if web[contact_type] and web[contact_type] != 'N/A':


### PR DESCRIPTION
The City Hall address contact type hard-coded into the scraper did not match the contact label in Legistar. 

<img width="384" alt="screen shot 2017-12-06 at 9 58 59 am" src="https://user-images.githubusercontent.com/12176173/33671054-339671b2-da6c-11e7-9e06-54f002367f12.png">

In effect, this prevented us from scraping any City Hall addresses.

<img width="761" alt="screen shot 2017-12-06 at 10 05 08 am" src="https://user-images.githubusercontent.com/12176173/33671343-fa18734e-da6c-11e7-8c57-243f2c0d692e.png">

This PR fixes the key so City Hall addresses are recorded appropriately.
