### PR TITLE
Add extras

### DIFF
--- a/nyc/bills.py
+++ b/nyc/bills.py
@@ -235,7 +235,8 @@ class NYCBillScraper(LegistarAPIBillScraper):
             self.version_errors.append(legistar_web)
             return None
 
-
+        bill.extras['local_classification'] = matter['MatterTypeName']
+        
         if text:
             if text['MatterTextPlain']:
                 bill.extras['plain_text'] = text['MatterTextPlain'].replace(u'\u0000', '')


### PR DESCRIPTION
This PR adds "local_classification" to extras, since the[ `import_data` in django-councilmatic uses this value to create bill_types](https://github.com/datamade/django-councilmatic/blob/master/councilmatic_core/management/commands/import_data.py#L952).