### PR TITLE
Scrape all NYC bills via window=0

### DIFF
--- a/nyc/bills.py
+++ b/nyc/bills.py
@@ -236,7 +236,7 @@ class NYCBillScraper(LegistarAPIBillScraper):
             return None
 
         bill.extras['local_classification'] = matter['MatterTypeName']
-        
+
         if text:
             if text['MatterTextPlain']:
                 bill.extras['plain_text'] = text['MatterTextPlain'].replace(u'\u0000', '')
@@ -276,15 +276,35 @@ class NYCBillScraper(LegistarAPIBillScraper):
 
 
     def scrape(self, window=3, matter_ids=None):
+        '''By default, scrape legislation updated in the last three days.
+        Optionally specify a larger or smaller window of time from which to
+        scrape updates, or specific matters to scrape.
+
+        Note that passing a value for :matter_ids supercedes the value of
+        :window, such that the given matters will be scraped regardless of
+        when they were updated.
+
+        Optional parameters
+
+        :window (numeric) - Amount of time for which to scrape updates, e.g.
+        a window of 7 will scrape legislation updated in the last week. Pass
+        a window of 0 to scrape all legislation.
+
+        :matter_ids (str) - Comma-separated list of matter IDs to scrape
+        '''
         self.version_errors = []
 
         if matter_ids:
             matters = [self.matter(matter_id) for matter_id in matter_ids.split(',')]
             matters = filter(None, matters)  # Skip matters that are not yet in Legistar
 
-        else:
+        elif int(window):
             n_days_ago = datetime.datetime.utcnow() - datetime.timedelta(float(window))
             matters = self.matters(n_days_ago)
+
+        else:
+            # Scrape all matters, including those without a last-modified date
+            matters = self.matters()
 
         for matter in matters:
             bill = self.get_bill(matter)


### PR DESCRIPTION
Some bills in the NYC API don't have a last-updated date, and so will never be scraped in our current setup. Update the bills scraper to call `self.matters` without a last-updated date when `window=0` so that all matters, including those that lack last-updated date, can be scraped.