### PR TITLE
Only strip names at point of Person object creation in NYC people scraper

### DIFF
--- a/nyc/people.py
+++ b/nyc/people.py
@@ -25,14 +25,19 @@ class NYCPersonScraper(LegistarAPIPersonScraper):
         web_info = {}
 
         for member, _ in web_scraper.councilMembers():
-            web_info[member['Person Name']['label']] = member
+            # Some names in Legistar have trailing spaces. Leave those in tact
+            # when storing and accessing information about members from the
+            # dicts in this module. Only format at the point of creating a
+            # Person object for the OCD API.
+            name = member['Person Name']['label']
+            web_info[name] = member
 
         city_council, = [body for body in self.bodies()
                          if body['BodyName'] == 'City Council']
 
         terms = collections.defaultdict(list)
 
-        public_advocates = { # Match casing to Bill De Blasio as council member
+        public_advocates = {  # Match casing to Bill De Blasio as council member
             'The Public Advocate (Mr. de Blasio)': 'Bill De Blasio',
             'The Public Advocate (Ms. James)': 'Letitia James',
         }
@@ -50,11 +55,11 @@ class NYCPersonScraper(LegistarAPIPersonScraper):
         members = {}
 
         for member, offices in terms.items():
-            member = member.strip()  # Remove trailing space
 
-            p = Person(member)
+            formatted_name = member.strip()
+            p = Person(formatted_name)
 
-            web = web_info.get(member)
+            web = web_info[member]
 
             for term in offices:
                 role = term['OfficeRecordTitle']
@@ -157,7 +162,7 @@ class NYCPersonScraper(LegistarAPIPersonScraper):
                     else:
                         role = 'Member'
 
-                    person = office['OfficeRecordFullName'].strip()
+                    person = office['OfficeRecordFullName']
                     person = public_advocates.get(person, person)
 
                     if person in members:


### PR DESCRIPTION
In the people scraper, we add people to the `web_info` dict without formatting the name string, [(1)](https://github.com/opencivicdata/scrapers-us-municipal/blob/a5096da67dc94719c7ca2812c6fff8c7182c56a3/nyc/people.py#L28), [(2)](https://github.com/opencivicdata/scrapers-us-municipal/blob/a5096da67dc94719c7ca2812c6fff8c7182c56a3/nyc/people.py#L41-L48); however, we try to access them with a formatted name string, [(3)](https://github.com/opencivicdata/scrapers-us-municipal/blob/a5096da67dc94719c7ca2812c6fff8c7182c56a3/nyc/people.py#L53-L57), and moreover add them to the `members` dict (used later) with that formatted string, [(4)](https://github.com/opencivicdata/scrapers-us-municipal/blob/a5096da67dc94719c7ca2812c6fff8c7182c56a3/nyc/people.py#L117).

For the sake of simplicity, this PR saves and accesses people in local dicts via unformatted names, e.g., formatting is only performed for the creation of a `Person` object for the OCD API. It also uses plain old key access, rather than `get`, [in this line](https://github.com/opencivicdata/scrapers-us-municipal/blob/a5096da67dc94719c7ca2812c6fff8c7182c56a3/nyc/people.py#L57), because [we add members to the `web_info` dict if they are not already in it](https://github.com/opencivicdata/scrapers-us-municipal/blob/a5096da67dc94719c7ca2812c6fff8c7182c56a3/nyc/people.py#L47-L48).