### PR TITLE
Always strip names in NYC people scraper

### DIFF
--- a/nyc/bills.py
+++ b/nyc/bills.py
@@ -10,7 +10,8 @@ from pupa.utils import _make_pseudo_id
 from .secrets import TOKEN
 
 DUPLICATED_ACTIONS = {21445, 28507, 28481,
-                      49987, 48426} #these two are stations of the cities weird special events
+                      49987, 48426}  # These two are stations of the cities
+                                     # weird special events.
 
 class NYCBillScraper(LegistarAPIBillScraper):
     LEGISLATION_URL = 'http://legistar.council.nyc.gov/Legislation.aspx'

--- a/nyc/people.py
+++ b/nyc/people.py
@@ -48,14 +48,14 @@ class NYCPersonScraper(LegistarAPIPersonScraper):
             if name not in web_info:
                 web_info[name] = collections.defaultdict(lambda: None)
 
-        members = {}
-
         # Check that we have everyone we expect, formatted consistently, in
         # both information arrays. For instance, this will fail if we forget to
         # strip trailing spaces from names on one side or the other (which has
         # the effect of omitting information, such as post, from the scrape).
 
         assert set(web_info.keys()) == set(terms.keys())
+
+        members = {}
 
         for member, offices in terms.items():
 
@@ -165,7 +165,7 @@ class NYCPersonScraper(LegistarAPIPersonScraper):
                         role = 'Member'
 
                     person = office['OfficeRecordFullName']
-                    person = public_advocates.get(person, person)
+                    person = public_advocates.get(person, person).strip()
 
                     if person in members:
                         p = members[person]


### PR DESCRIPTION
The previous approach of only formatting names at the saving to the OCD API assumed that trailing spaces were consistent between the Legistar GUI and the Legistar API. As it turns out, this is not always the case, which means that we'd lose information, i.e., post, in the scrape where the spaces weren't consistent. This PR strips all names, everywhere in the people scraper.
 
FWIW, here's the impact on my local import after the changes:

```
import:
  jurisdiction: 0 new 0 updated 1 noop
  membership: 49 new 0 updated 3420 noop
  organization: 0 new 0 updated 131 noop
  person: 2 new 8 updated 184 noop
  post: 0 new 0 updated 51 noop
```