### PR TITLE
Update Chicago scraper to reflect new table heading in event list

### DIFF
--- a/chicago/events.py
+++ b/chicago/events.py
@@ -98,7 +98,7 @@ class ChicagoEventsScraper(LegistarAPIEventScraper) :
 
             self.addDocs(e, event, 'Agenda')
             self.addDocs(e, event, 'Notice')
-            self.addDocs(e, event, 'Transcript')
+            self.addDocs(e, event, 'Captions')
             self.addDocs(e, event, 'Summary')
 
             participant = event["Name"]["label"]


### PR DESCRIPTION
They changed "Transcript" to "Captions", so let's follow suit (and resolve [this KeyError](https://sentry.io/datamade/scrapers-us-municipal/issues/476066019/events/14921912070/)).

Cached site:
<img width="346" alt="screen shot 2018-02-28 at 3 48 05 pm" src="https://user-images.githubusercontent.com/12176173/36814957-cc4e21e2-1c9e-11e8-959a-e08034e18c15.png">

Live site:
<img width="391" alt="screen shot 2018-02-28 at 3 47 59 pm" src="https://user-images.githubusercontent.com/12176173/36814958-cc61fa3c-1c9e-11e8-850f-9dc6e2e45b51.png">
