### PR TITLE
New pupa

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 https://github.com/opencivicdata/python-opencivicdata-django/zipball/master
-https://github.com/opencivicdata/pupa/zipball/0bc7fc0dfdae0af8f31830477eca6a85450125d2
+https://github.com/opencivicdata/pupa/zipball/master
 https://github.com/opencivicdata/python-legistar-scraper/zipball/master
 lxml
 sh 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 https://github.com/opencivicdata/python-opencivicdata-django/zipball/master
-https://github.com/opencivicdata/pupa/zipball/master
+pupa==0.9.0
 https://github.com/opencivicdata/python-legistar-scraper/zipball/master
 lxml
 sh 


### PR DESCRIPTION
This PR updates requirements to include latest release of pupa ([in line with master](https://github.com/opencivicdata/pupa/commits/master)), which removes the `fix_bill_id` function.