### PR TITLE
match english and spanish events for la metro 

### DIFF
--- a/lametro/events.py
+++ b/lametro/events.py
@@ -26,8 +26,8 @@ class LametroEventScraper(LegistarAPIEventScraper):
 
     def _sort_event_pair(self, pair):
         '''
-        Given event pair like "Board of Directors" and "Board of Directors
-        (SAP)," return tuple such that English event comes first.
+        Given event pair like "Board of Directors" and "Board of Directors (SAP)",
+        return tuple such that English event comes first.
         '''
         event_pair = sorted(pair, key=lambda x: x['EventBodyName'])
         return tuple(event_pair)

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -31,6 +31,13 @@ class LametroEventScraper(LegistarAPIEventScraper):
         return paired_events, unpaired_events
 
     def _find_partner(self, event):
+        '''
+        Attempt to find other-language partner of an
+        event. Sometimes English events won't have Spanish
+        partners, but every Spanish event should have an
+        English partner.
+        '''
+
 
         results = list(self.search('/events/', 'EventId',
                                    event.partner_search_string))
@@ -45,25 +52,26 @@ class LametroEventScraper(LegistarAPIEventScraper):
 
         else:
             return None
-        
 
     def api_events(self, *args, **kwargs):
         '''
-        For meetings, Metro provides an English audio recording and a
-        Spanish recording. Due to limitations with the InSite system,
-        multiple audio recordings can't be associated with a single
-        InSite event. So, Metro creates two InSite event entries for
-        the same actual event, one Insite event entry has the English
-        audio and the other has the Spanish Audio. The Spanish InSite
-        event entry has the same name as the English event entry,
-        except the name is suffixed with ' (SAP)'.
+        For meetings, Metro provides an English audio recording and
+        sometimes a Spanish audio translation. Due to limitations with
+        the InSite system, multiple audio recordings can't be
+        associated with a single InSite event. So, Metro creates two
+        InSite event entries for the same actual event, one Insite
+        event entry has the English audio and the other has the
+        Spanish audio. The Spanish InSite event entry has the same
+        name as the English event entry, except the name is suffixed
+        with ' (SAP)'.
 
         We need to merge these companion events. In order to do that,
-        we must ensure that if we scrape one member of pair, we also
+        we must ensure that if we scrape one member of a pair, we also
         scrape its partner.
 
         This method subclasses the normal api_event method to ensure
         that we get both members of pairs.
+
         '''
         events = (LAMetroAPIEvent(event) for event
                   in super().api_events(*args, **kwargs))
@@ -229,5 +237,3 @@ class LAMetroAPIEvent(dict):
         search_string += " and EventTime eq '{}'".format(self['EventTime'])
 
         return search_string
-
-    

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -12,6 +12,37 @@ class LametroEventScraper(LegistarAPIEventScraper):
     EVENTSPAGE = "https://metro.legistar.com/Calendar.aspx"
     TIMEZONE = "America/Los_Angeles"
 
+    def _pair_english_with_spanish_events(self):
+        pass
+
+    def search(self):
+
+    def api_events(self, *args, **kwargs):
+        events = list(super().api_events(*args, **kwargs))
+        paired, unpaired = self._pair_english_with_spanish_events(events)
+
+        yield from paired
+
+        for event in unpaired:
+            pass
+            # event_name = event['name']
+            # anglo_event = not event_name.endswith('(SAP)')
+            # if anglo_event:
+            #     spanish_event_name = '{} (SAP)'.format(anglo_event)
+            #     try:
+            #         spanish_event = self.search(name=spanish_event_name)
+            #         yield (event, spanish_event)
+            #     except DoesNotExist:
+            #         pass
+            # else:
+            #     anglo_event_name = event_name.rstrip(' (SAP)')
+            #     try:
+            #         anglo_event = self.search(name=anglo_event_name)
+            #         yield (anglo_event, event)
+            #     except DoesNotExist:
+            #         pass
+
+
     def scrape(self, window=None) :
         if window:
             n_days_ago = datetime.datetime.utcnow() - datetime.timedelta(float(window))

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -46,11 +46,24 @@ class LametroEventScraper(LegistarAPIEventScraper):
 
     def api_events(self, *args, **kwargs):
         '''
-        Return tuples of (English, Spanish) events. Events that cannot
-        be found are None.
+        For meetings, Metro provides an English audio recording and a
+        Spanish recording. Due to limitations with the InSite system,
+        multiple audio recordings can't be associated with a single
+        InSite event. So, Metro creates two InSite event entries for
+        the same actual event, one Insite event entry has the English
+        audio and the other has the Spanish Audio. The Spanish InSite
+        event entry has the same name as the English event entry,
+        except the name is suffixed with ' (SAP)'.
+
+        We need to merge these companion events. In order to do that,
+        we must ensure that if we scrape one member of pair, we also
+        scrape its partner.
+
+        This method subclasses the normal api_event method to ensure
+        that we get both members of pairs.
         '''
-        events = [APIEvent(event) for event
-                  in super().api_events(*args, **kwargs)]
+        events = (APIEvent(event) for event
+                  in super().api_events(*args, **kwargs))
 
         paired, unpaired = self._pair_events(events)
 

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -42,6 +42,9 @@ class LametroEventScraper(LegistarAPIEventScraper):
 
         elif event.is_spanish:
             raise ValueError("Can't find English companion for Spanish Event {}".format(event['EventId']))
+
+        else:
+            return None
         
 
     def api_events(self, *args, **kwargs):
@@ -70,10 +73,11 @@ class LametroEventScraper(LegistarAPIEventScraper):
         yield from paired
 
         for unpaired_event in unpaired:
-            partner_event = self._find_partner(unpaired_event)
-
             yield unpaired_event
-            yield partner_event
+
+            partner_event = self._find_partner(unpaired_event)
+            if partner_event is not None:
+                yield partner_event
 
     def _merge_events(self, events):
         english_events = []

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -36,7 +36,7 @@ class LametroEventScraper(LegistarAPIEventScraper):
                                    event.partner_search_string))
         if results:
             partner, = results
-            partner = APIEvent(partner)
+            partner = LAMetroAPIEvent(partner)
             assert event.is_partner(partner)
             return partner
 
@@ -62,7 +62,7 @@ class LametroEventScraper(LegistarAPIEventScraper):
         This method subclasses the normal api_event method to ensure
         that we get both members of pairs.
         '''
-        events = (APIEvent(event) for event
+        events = (LAMetroAPIEvent(event) for event
                   in super().api_events(*args, **kwargs))
 
         paired, unpaired = self._pair_events(events)
@@ -195,7 +195,12 @@ class LametroEventScraper(LegistarAPIEventScraper):
             yield e
             
 
-class APIEvent(dict):
+class LAMetroAPIEvent(dict):
+    '''
+    This classs if for adding methods to the event dict
+    to faciliate maching events with their other-language
+    partners
+    '''
 
     @property
     def is_spanish(self):


### PR DESCRIPTION
legistar doesn't natively support multi-lingual support for events, so they are added a near-duplicates. we are going to scrape them as one event, and so must match them. 