### PR TITLE
unpaired events

### DIFF
--- a/lametro/events.py
+++ b/lametro/events.py
@@ -25,7 +25,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                 paired_events.append(incoming_event)
                 paired_events.append(partner_event)
 
-        return paired_events, unpaired_events
+        return paired_events, unpaired_events.values()
 
     def _find_partner(self, event):
         '''


### PR DESCRIPTION
This fixes a bug I introduced in #223 that prevented us from scraping unpaired events. 