### PR TITLE
Make Board of Directors Metro matter sponsor resolve-able to organization

### DIFF
--- a/lametro/bills.py
+++ b/lametro/bills.py
@@ -42,7 +42,12 @@ class LametroBillScraper(Scraper, LegistarAPIBillScraper):
                 sponsorship['primary'] = False
                 sponsorship['classification'] = "Regular"
 
-            sponsorship['name'] = sponsor['MatterSponsorName'].strip()
+            sponsor_name = sponsor['MatterSponsorName'].strip()
+
+            if sponsor_name == 'Board of Directors - Regular Board Meeting':
+                sponsor_name = 'Board of Directors'
+
+            sponsorship['name'] = sponsor_name
             sponsorship['entity_type'] = 'organization'
             
             yield sponsorship


### PR DESCRIPTION
So, it seems like Metro calls the Board of Directors "Board of Directors – Regular Board Meeting" when it's listed as a sponsor in Legistar. `pupa` can't resolve this to the correct organization. This PR removes the board meeting suffix from "Board of Directors" when scraping matter sponsorships.