### PR TITLE
Use legislative sessions defined on __init__ in Metro scraper

### DIFF
--- a/lametro/__init__.py
+++ b/lametro/__init__.py
@@ -17,7 +17,7 @@ class Lametro(Jurisdiction):
     }
 
     legislative_sessions = []
-    for year in range(2014, 2018):
+    for year in range(2014, 2019):
         session = {"identifier": "{}".format(year),
                    "start_date": "{}-07-01".format(year),
                    "end_date": "{}-06-30".format(year + 1)}

--- a/lametro/bills.py
+++ b/lametro/bills.py
@@ -20,17 +20,19 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
                     'present' : 'abstain'}
 
     def session(self, action_date) :
+        from . import Lametro
+
         localize = pytz.timezone(self.TIMEZONE).localize
-        if action_date <  localize(datetime.datetime(2015, 7, 1)) :
-            return "2014"
-        if action_date <  localize(datetime.datetime(2016, 7, 1)) :
-            return "2015"
-        if action_date <  localize(datetime.datetime(2017, 7, 1)) :
-            return "2016"
-        if action_date <  localize(datetime.datetime(2018, 7, 1)) :
-            return "2017"                 
-        else:
-            raise ValueError("Invalid action date: {}".format(action_date))
+        fmt = '%Y-%m-%d'
+
+        for session in Lametro.legislative_sessions:
+            start_datetime = datetime.datetime.strptime(session['start_date'], fmt)
+            end_datetime = datetime.datetime.strptime(session['end_date'], fmt)
+
+            if localize(start_datetime) <= action_date <= localize(end_datetime):
+                return session['identifier']
+
+        raise ValueError("Invalid action date: {}".format(action_date))
 
     def sponsorships(self, matter_id) :
         for i, sponsor in enumerate(self.sponsors(matter_id)) :


### PR DESCRIPTION
The old `sessions` method required dates to be updated in two places. This refactor allows for an update in one place (and adds the new session).