### PR TITLE
Defensively assert that no Spanish events remain unpaired

### DIFF
--- a/lametro/events.py
+++ b/lametro/events.py
@@ -14,11 +14,11 @@ class UnmatchedEventError(Exception):
         if type(events) is dict:
             message = message_format.format(events['EventId'], events['EventTime'], \
             events['EventDate'], EventInSiteURL['EventInSiteURL'], '')
-        elif type(events) is list and type(events[0]) is tuple:
+        elif type(events) is list:
             message = ''
-            for event in events: # indexed because each event is a tuple
-                temp = message_format.format(event[0]['EventId'], event[0]['EventTime'], \
-                            event[0]['EventDate'], event[0]['EventInSiteURL'], '\n')
+            for event in events:
+                temp = message_format.format(event['EventId'], event['EventTime'], \
+                            event['EventDate'], event['EventInSiteURL'], '\n')
                 message += temp
         else:
             message = "Can't find companion event"
@@ -166,8 +166,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
         try:
             assert not spanish_events  # These should all be merged with an English event.
         except AssertionError:
-            import ipdb; ipdb.set_trace()
-            unpaired_events = [event for event in spanish_events.values()]
+            unpaired_events = [event for event, _ in spanish_events.values()]
             raise UnmatchedEventError(unpaired_events)
 
         return english_events

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -101,6 +101,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
     def _merge_events(self, events):
         english_events = []
         spanish_events = {}
+        test_event = None
 
         for event, web_event in events:
             web_event = LAMetroWebEvent(web_event)
@@ -113,6 +114,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
         for event, web_event in english_events:
             event_details = []
             event_audio = []
+            test_event = event
 
             if web_event.has_detail_url:
                 event_details.append({
@@ -143,6 +145,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
 
             event['event_details'] = event_details
             event['audio'] = event_audio
+            test_event = event
 
         try:
             assert not spanish_events  # These should all be merged with an English event.

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -166,7 +166,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
         try:
             assert not spanish_events  # These should all be merged with an English event.
         except AssertionError:
-            unpaired_events = [event for event in spanish_events.values())]
+            unpaired_events = [event for event in spanish_events.values()]
             raise UnmatchedEventError(unpaired_events)
 
         return english_events

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -92,8 +92,8 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                 if partner_event is not None:
                     yield partner_event
                 else:
-                    logging.warning('No Spanish/English match found for {0} {1} {2}'.format(
-                        unpaired_event['EventBodyName'], unpaired_event['EventDate'], unpaired_event['EventTime']))
+                    logging.warning('Cannot find Spanish companion event for {0} on {1} at {2}. {3}'.format(
+                        unpaired_event['EventBodyName'], unpaired_event['EventDate'], unpaired_event['EventTime'], unpaired_event['EventInSiteURL']))
 
     def _merge_events(self, events):
         english_events = []

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -105,7 +105,6 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
     def _merge_events(self, events):
         english_events = []
         spanish_events = {}
-        test_event = None
 
         for event, web_event in events:
             web_event = LAMetroWebEvent(web_event)
@@ -118,7 +117,6 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
         for event, web_event in english_events:
             event_details = []
             event_audio = []
-            test_event = event
 
             if web_event.has_detail_url:
                 event_details.append({
@@ -149,7 +147,6 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
 
             event['event_details'] = event_details
             event['audio'] = event_audio
-            test_event = event
 
         try:
             assert not spanish_events  # These should all be merged with an English event.

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -101,6 +101,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
     def _merge_events(self, events):
         english_events = []
         spanish_events = {}
+        test_event = None
 
         for event, web_event in events:
             web_event = LAMetroWebEvent(web_event)
@@ -113,6 +114,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
         for event, web_event in english_events:
             event_details = []
             event_audio = []
+            test_event = event
 
             if web_event.has_detail_url:
                 event_details.append({
@@ -143,12 +145,16 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
 
             event['event_details'] = event_details
             event['audio'] = event_audio
+            test_event = event
 
         try:
             assert not spanish_events  # These should all be merged with an English event.
-
         except AssertionError:
             unpaired_events = '\n'.join(str(web_event) for _, web_event in spanish_events.values())
+
+            for key, value in spanish_events.items():
+                logging.warning('Orphaned Spanish event: {0} at {1} on {2} - {3}'.format(value[0]['EventBodyName'], value[0]['EventDate'], value[0]['EventTime'], value[0]['EventInSiteURL']))
+
             raise AssertionError('Unpaired Spanish events remain:\n{}'.format(unpaired_events))
 
         return english_events

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -101,7 +101,6 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
     def _merge_events(self, events):
         english_events = []
         spanish_events = {}
-        test_event = None
 
         for event, web_event in events:
             web_event = LAMetroWebEvent(web_event)
@@ -114,7 +113,6 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
         for event, web_event in english_events:
             event_details = []
             event_audio = []
-            test_event = event
 
             if web_event.has_detail_url:
                 event_details.append({
@@ -145,7 +143,6 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
 
             event['event_details'] = event_details
             event['audio'] = event_audio
-            test_event = event
 
         try:
             assert not spanish_events  # These should all be merged with an English event.

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -9,12 +9,22 @@ from legistar.base import LegistarScraper
 LOGGER = logging.getLogger(__name__)
 
 class UnmatchedEventError(Exception):
-    def __init__(self, event):
-        self.message = "Can't find companion for Event \
+    def __init__(self, events):
+        if type(events) is dictionary:
+            message = "Can't find companion for Event \
                                     {0} at {1} on {2} - {3}" \
-                                    .format(event['EventId'], event['EventTime'], \
-                                    event['EventDate'], event['EventInSiteURL'])
-        self.event = event
+                                    .format(events['EventId'], events['EventTime'], \
+                                    events['EventDate'], EventInSiteURL['EventInSiteURL'])
+        elif type(events) is list:
+            message = ''
+            for event in events:
+                temp = "Can't find companion for Event \
+                                        {0} at {1} on {2} - {3} \n" \
+                                        .format(event['EventId'], event['EventTime'], \
+                                        event['EventDate'], event['EventInSiteURL'])
+                message += temp
+
+        super().__init__(message)
 
 class LametroEventScraper(LegistarAPIEventScraper, Scraper):
     BASE_URL = 'http://webapi.legistar.com/v1/metro'
@@ -154,9 +164,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
             unpaired_events = '\n'.join(str(web_event) for _, web_event in spanish_events.values())
 
             for key, value in spanish_events.items():
-                raise UnmatchedEventError(value[0])
-
-            raise AssertionError('Unpaired Spanish events remain:\n{}'.format(unpaired_events))
+                UnmatchedEventError(value[0])
 
         return english_events
 

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -161,10 +161,8 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
         try:
             assert not spanish_events  # These should all be merged with an English event.
         except AssertionError:
-            unpaired_events = '\n'.join(str(web_event) for _, web_event in spanish_events.values())
-
-            for key, value in spanish_events.items():
-                UnmatchedEventError(value[0])
+            unpaired_events = [event for event in spanish_events.values())]
+            raise UnmatchedEventError(unpaired_events)
 
         return english_events
 

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -146,7 +146,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
 
         except AssertionError:
             unpaired_events = '\n'.join(str(web_event) for _, web_event in spanish_events.values())
-            logging.warning('Unpaired Spanish events remain:\n{}'.format(unpaired_events))
+            raise AssertionError('Unpaired Spanish events remain:\n{}'.format(unpaired_events))
 
         return english_events
 

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -14,11 +14,11 @@ class UnmatchedEventError(Exception):
         if type(events) is dict:
             message = message_format.format(events['EventId'], events['EventTime'], \
             events['EventDate'], EventInSiteURL['EventInSiteURL'], '')
-        elif type(events) is list:
+        elif type(events) is list and type(events[0]) is tuple:
             message = ''
-            for event in events:
-                temp = message_format.format(event['EventId'], event['EventTime'], \
-                            event['EventDate'], event['EventInSiteURL'], '\n')
+            for event in events: # indexed because each event is a tuple
+                temp = message_format.format(event[0]['EventId'], event[0]['EventTime'], \
+                            event[0]['EventDate'], event[0]['EventInSiteURL'], '\n')
                 message += temp
         else:
             message = "Can't find companion event"
@@ -166,6 +166,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
         try:
             assert not spanish_events  # These should all be merged with an English event.
         except AssertionError:
+            import ipdb; ipdb.set_trace()
             unpaired_events = [event for event in spanish_events.values()]
             raise UnmatchedEventError(unpaired_events)
 

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -47,7 +47,10 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
             return partner
 
         elif event.is_spanish:
-            logger.warning("Can't find English companion for Spanish Event {}".format(event['EventId']))
+            raise ValueError("Can't find English companion for Spanish Event \
+                                        {0} at {1} on {2} - {3}"
+                                        .format(event['EventId'], event['EventTime'],
+                                        event['EventDate'], event['EventInSiteURL']))
 
         else:
             return None

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -94,7 +94,6 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                 else:
                     logging.warning('No Spanish/English match found for {0} {1} {2}'.format(
                         unpaired_event['EventBodyName'], unpaired_event['EventDate'], unpaired_event['EventTime']))
-                    import ipdb; ipdb.set_trace()
 
     def _merge_events(self, events):
         english_events = []

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -114,7 +114,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
             if web_event.has_audio:
                 event_audio.append(web_event['Audio'])
 
-            matches = spanish_events.get(event.partner_key, None)
+            matches = spanish_events.pop(event.partner_key, None)
 
             if matches:
                 spanish_event, spanish_web_event = matches
@@ -134,6 +134,13 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
 
             event['event_details'] = event_details
             event['audio'] = event_audio
+
+        try:
+            assert not spanish_events  # These should all be merged with an English event.
+
+        except AssertionError:
+            unpaired_events = '\n'.join(str(web_event) for _, web_event in spanish_events.values())
+            raise AssertionError('Unpaired Spanish events remain:\n{}'.format(unpaired_events))
 
         return english_events
 


### PR DESCRIPTION
We use the name, date, and time to pair English and Spanish events. Today, the time for an event pair did not match, so the scraper did not merge the events, resulting in an orphaned Spanish event that disappeared into the ether. We're still learning whether the times did not match in error or on purpose, but it would be good to know when our expectations are violated. This PR performs a defensive assertion that we've paired all Spanish events.