### PR TITLE
Add an extras field only to 'current' acting members

### DIFF
--- a/lametro/people.py
+++ b/lametro/people.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import date
 import collections
 
 from legistar.people import LegistarAPIPersonScraper, LegistarPersonScraper
@@ -131,12 +131,14 @@ class LametroPersonScraper(LegistarAPIPersonScraper, Scraper):
 
                         members[person] = p
 
+                    start_date = self.toDate(office['OfficeRecordStartDate'])
+                    end_date = self.toDate(office['OfficeRecordEndDate'])
                     membership = p.add_membership(organization_name,
                                      role=role,
-                                     start_date = self.toDate(office['OfficeRecordStartDate']),
-                                     end_date = self.toDate(office['OfficeRecordEndDate']))
+                                     start_date=start_date,
+                                     end_date=end_date)
 
-                    if p.name in ACTING_MEMBERS:
+                    if p.name in ACTING_MEMBERS and date.today() < end_date:
                         membership.extras = {'acting': 'true'}
 
                 yield o

--- a/lametro/people.py
+++ b/lametro/people.py
@@ -27,7 +27,7 @@ VOTING_POSTS = {'Jacquelyn Dupont-Walker' : 'Appointee of Mayor of the City of L
 NONVOTING_POSTS = {'Carrie Bowen' : 'Appointee of Governor of California',
                    'Shirley Choate' : 'Caltrans District 7 Director, Appointee of Governor of California'}
 
-ACTING_MEMBERS = ['Shirley Choate']
+ACTING_MEMBERS_WITH_END_DATE = {'Shirley Choate': date(2019, 6, 30)}
 
 class LametroPersonScraper(LegistarAPIPersonScraper, Scraper):
     BASE_URL = 'http://webapi.legistar.com/v1/metro'
@@ -138,7 +138,8 @@ class LametroPersonScraper(LegistarAPIPersonScraper, Scraper):
                                      start_date=start_date,
                                      end_date=end_date)
 
-                    if p.name in ACTING_MEMBERS and date.today() < end_date:
+                    acting_member_end_date = ACTING_MEMBERS_WITH_END_DATE.get(p.name)
+                    if acting_member_end_date and acting_member_end_date <= end_date:
                         membership.extras = {'acting': 'true'}
 
                 yield o


### PR DESCRIPTION
@fgregg - I think it's more accurate to add `acting: true` to current memberships only (since we do not know the status of her post during previous legislative sessions). 