### PR TITLE
Treat CEO as a role in committees, as the scraper does with the Board

### DIFF
--- a/lametro/people.py
+++ b/lametro/people.py
@@ -116,7 +116,8 @@ class LametroPersonScraper(LegistarAPIPersonScraper, Scraper):
                 for office in self.body_offices(body):
                     role = office['OfficeRecordTitle']
 
-                    if role not in ("Chair", "Vice Chair"):
+
+                    if role not in ("Chair", "Vice Chair", "Chief Executive Officer"):
                         if role == 'non-voting member':
                             role = 'Nonvoting Member'
                         else:


### PR DESCRIPTION
This PR uses "Chief Executive Officer" as a role in Metro, since the Metro CEO is neither a "member" nor "non-voting member" of committees.

Related to https://github.com/datamade/la-metro-councilmatic/issues/351