### PR TITLE
Add MatterRestrictViewViaWeb to extras

### DIFF
--- a/lametro/bills.py
+++ b/lametro/bills.py
@@ -222,6 +222,7 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
                                            media_type="application/pdf")
 
             bill.extras = {'local_classification' : matter['MatterTypeName']}
+            bill.extras = {'restrict_view' : matter['MatterRestrictViewViaWeb']}
 
             text = self.text(matter_id)
 


### PR DESCRIPTION
This PR adds `MatterRestrictViewViaWeb` to the extras field for Metro bills. It handles the very first portion of https://github.com/datamade/la-metro-councilmatic/issues/345