### PR TITLE
Add token to params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .#*
 *#
 nyc/secrets.py
+lametro/secrets.py
 pupa_settings.py
 
 # Pupa bits.

--- a/lametro/bills.py
+++ b/lametro/bills.py
@@ -9,8 +9,10 @@ from pupa.utils import _make_pseudo_id
 
 from legistar.bills import LegistarBillScraper, LegistarAPIBillScraper
 
+from .secrets import TOKEN
+
 class LametroBillScraper(LegistarAPIBillScraper, Scraper):
-    BASE_URL = 'http://webapi.legistar.com/v1/metro'
+    BASE_URL = 'https://webapi.legistar.com/v1/metro'
     BASE_WEB_URL = 'https://metro.legistar.com'
     TIMEZONE = "America/Los_Angeles"
 
@@ -18,6 +20,13 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
                     'nay' : 'no',
                     'recused' : 'abstain',
                     'present' : 'abstain'}
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # This adds default param values to all requests made by
+        # this session
+        self.params = {'Token': TOKEN}
 
     def session(self, action_date) :
         from . import Lametro

--- a/lametro/bills.py
+++ b/lametro/bills.py
@@ -22,10 +22,14 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
                     'present' : 'abstain'}
 
     def __init__(self, *args, **kwargs):
+        '''
+        Initialize the Bill scraper with default param values,
+        and set the `scrape_restricted` property to True. 
+        Together, they enable the scraping of private bills, i.e., 
+        bills with 'MatterRestrictViewViaWeb' set as True.
+        '''
         super().__init__(*args, **kwargs)
 
-        # This adds default param values to all requests made by
-        # this session
         self.params = {'Token': TOKEN}
         self.scrape_restricted = True
 
@@ -104,7 +108,7 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
 
                 yield bill_action, votes
 
-    def scrape(self, window=28, matter_ids=None, scrape_restricted=True) :
+    def scrape(self, window=28, matter_ids=None) :
         '''By default, scrape board reports updated in the last 28 days.
         Optionally specify a larger or smaller window of time from which to
         scrape updates, or specific matters to scrape.
@@ -117,19 +121,17 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
         a window of 7 will scrape legislation updated in the last week. Pass
         a window of 0 to scrape all legislation.
         :matter_ids (str) - Comma-separated list of matter IDs to scrape
-        :scrape_restricted - A Boolean indicating that the scrape should either
-        skip or include restricted (i.e., private) bills.
         '''
 
         if matter_ids:
-            matters = [self.matter(matter_id, scrape_restricted) for matter_id in matter_ids.split(',')]
+            matters = [self.matter(matter_id) for matter_id in matter_ids.split(',')]
             matters = filter(None, matters)  # Skip matters that are not yet in Legistar
         elif float(window):  # Support for partial days, i.e., window=0.15
             n_days_ago = datetime.datetime.utcnow() - datetime.timedelta(float(window))
-            matters = self.matters(n_days_ago, scrape_restricted)
+            matters = self.matters(n_days_ago)
         else:
             # Scrape all matters, including those without a last-modified date
-            matters = self.matters(scrape_restricted)
+            matters = self.matters()
 
         n_days_ago = datetime.datetime.utcnow() - datetime.timedelta(float(window))
         for matter in matters:

--- a/lametro/bills.py
+++ b/lametro/bills.py
@@ -159,11 +159,11 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
                         classification=bill_type,
                         from_organization={"name":"Board of Directors"})
             
-            legistar_web = matter['legistar_url']
+            legistar_web = matter.get('legistar_url', '')
+            if legistar_web:
+                bill.add_source(legistar_web, note='web')
             
             legistar_api = self.BASE_URL + '/matters/{0}'.format(matter_id)
-
-            bill.add_source(legistar_web, note='web')
             bill.add_source(legistar_api, note='api')
 
             for identifier in alternate_identifiers:

--- a/lametro/bills.py
+++ b/lametro/bills.py
@@ -159,6 +159,17 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
                         classification=bill_type,
                         from_organization={"name":"Board of Directors"})
             
+            # Add comment here!
+            bill.extras = {'restrict_view' : matter['MatterRestrictViewViaWeb']}
+
+            if matter['MatterRestrictViewViaWeb']:
+                bill.title = 'Restricted View'
+                bill.save()
+                bill.add_subject('Restricted View')
+                bill.add_source('https://metro.legistar.com')
+
+                yield bill
+
             legistar_web = matter.get('legistar_url', '')
             if legistar_web:
                 bill.add_source(legistar_web, note='web')
@@ -236,7 +247,6 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
                                            media_type="application/pdf")
 
             bill.extras = {'local_classification' : matter['MatterTypeName']}
-            bill.extras = {'restrict_view' : matter['MatterRestrictViewViaWeb']}
 
             text = self.text(matter_id)
 

--- a/lametro/bills.py
+++ b/lametro/bills.py
@@ -236,7 +236,6 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
                                            media_type="application/pdf")
 
             bill.extras = {'local_classification' : matter['MatterTypeName']}
-            # The 
             bill.extras = {'restrict_view' : matter['MatterRestrictViewViaWeb']}
 
             text = self.text(matter_id)


### PR DESCRIPTION
This PR enables Metro to scrape private bills and also marks which bills do and do not have a restricted view.

It works in cooperation with the changes in https://github.com/opencivicdata/python-legistar-scraper/pull/81.