### PR TITLE
Add note to source_url

### DIFF
--- a/lametro/bills.py
+++ b/lametro/bills.py
@@ -171,7 +171,7 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
                 # required fields
                 bill.title = 'Restricted View'
                 bill.add_subject('Restricted View')
-                bill.add_source('https://metro.legistar.com', note='web')
+                bill.add_source(self.BASE_URL, note='api')
 
                 # wipe old data
                 bill.extras['plain_text'] = ''

--- a/lametro/bills.py
+++ b/lametro/bills.py
@@ -171,7 +171,7 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
                 # required fields
                 bill.title = 'Restricted View'
                 bill.add_subject('Restricted View')
-                bill.add_source('https://metro.legistar.com')
+                bill.add_source('https://metro.legistar.com', note='web')
 
                 # wipe old data
                 bill.extras['plain_text'] = ''

--- a/lametro/bills.py
+++ b/lametro/bills.py
@@ -167,11 +167,15 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
             # https://github.com/opencivicdata/pupa/blob/master/pupa/scrape/schemas/bill.py
             bill.extras = {'restrict_view' : matter['MatterRestrictViewViaWeb']}
 
+            # Add API source early. 
+            # Private bills should have this url for debugging.
+            legistar_api = self.BASE_URL + '/matters/{0}'.format(matter_id)
+            bill.add_source(legistar_api, note='api')
+
             if matter['MatterRestrictViewViaWeb']:
                 # required fields
                 bill.title = 'Restricted View'
                 bill.add_subject('Restricted View')
-                bill.add_source(self.BASE_URL, note='api')
 
                 # wipe old data
                 bill.extras['plain_text'] = ''
@@ -188,9 +192,6 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
             legistar_web = matter.get('legistar_url', '')
             if legistar_web:
                 bill.add_source(legistar_web, note='web')
-            
-            legistar_api = self.BASE_URL + '/matters/{0}'.format(matter_id)
-            bill.add_source(legistar_api, note='api')
 
             for identifier in alternate_identifiers:
                 bill.add_identifier(identifier)


### PR DESCRIPTION
This PR adds a note to the `source_url` of private bills. This change helps facilitate import on the Councilmatic side. 