### PR TITLE
Don't add dummy subject to restricted bills

### DIFF
--- a/lametro/bills.py
+++ b/lametro/bills.py
@@ -204,7 +204,6 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
             if self._is_restricted(matter):
                 # required fields
                 bill.title = 'Restricted View'
-                bill.add_subject('Restricted View')
 
                 # wipe old data
                 bill.extras['plain_text'] = ''


### PR DESCRIPTION
Bill subjects [defaults to an empty list](https://github.com/opencivicdata/python-opencivicdata/blob/master/opencivicdata/legislative/models/bill.py#L35). Adding a dummy subject to restricted bills leads to that subject appearing as a facet in Councilmatic when those bills are made public. Since we don't need to add a value, and we aren't using this dummy subject anyplace else downstream, let's not add it.