### PR TITLE
Agenda sequence dedupe

### DIFF
--- a/lametro/events.py
+++ b/lametro/events.py
@@ -210,7 +210,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                     agenda_item['extras']['item_agenda_sequence'] = item['EventItemAgendaSequence']
 
                 # Historically, the Legistar system has duplicated the EventItemAgendaSequence,
-                # resulting in data inaccuracies. The scrape should fail, until Metro
+                # resulting in data inaccuracies. The scrape should fail in such cases, until Metro
                 # cleans the data.
                 item_agenda_sequences = [item['extras']['item_agenda_sequence'] for item in e.agenda]
                 if len(item_agenda_sequences) != len(set(item_agenda_sequences)):

--- a/tests/lametro/conftest.py
+++ b/tests/lametro/conftest.py
@@ -65,6 +65,20 @@ def web_event():
     return web_event
 
 @pytest.fixture
+def event_agenda_item():
+    '''
+    Dictionary with pertinent info for an event item. 
+    It corresponds with the above api_event.
+    '''
+    agenda_item = {'EventItemGuid': '57DC7258-0E6D-42CA-BB9A-717FCC96E436',
+                   'EventItemEventId': 1473,
+                   'EventItemRollCallFlag': 0,
+                   'EventItemAgendaSequence': 12,
+                   'EventItemMinutesSequence': 12,
+                   'EventItemLastModifiedUtc': '2019-03-04T19:47:09.387',
+                   'EventItemTitle': 'Adjournment'}
+
+@pytest.fixture
 def matter():
     '''
     Dictionary with pertinent info for a bill. Bill is public.

--- a/tests/lametro/conftest.py
+++ b/tests/lametro/conftest.py
@@ -75,8 +75,12 @@ def event_agenda_item():
                    'EventItemRollCallFlag': 0,
                    'EventItemAgendaSequence': 12,
                    'EventItemMinutesSequence': 12,
+                   'EventItemMatterFile': None,
+                   'EventItemAgendaNumber': None,
                    'EventItemLastModifiedUtc': '2019-03-04T19:47:09.387',
                    'EventItemTitle': 'Adjournment'}
+
+    return agenda_item
 
 @pytest.fixture
 def matter():

--- a/tests/lametro/test_events.py
+++ b/tests/lametro/test_events.py
@@ -31,3 +31,28 @@ def test_status_assignment(event_scraper,
 
         for event in event_scraper.scrape():
             assert event.status == scraper_assigned_status
+
+def test_sequence_duplicate_error(event_scraper,
+                                  api_event, 
+                                  web_event,
+                                  mocker):
+    with requests_mock.Mocker() as m:
+        matcher = re.compile('webapi.legistar.com')
+        m.get(matcher, json={}, status_code=200)
+
+        matcher = re.compile('metro.legistar.com')
+        m.get(matcher, json={}, status_code=200)
+
+        api_event['event_details'] = {'note': 'web', 
+                                      'url': 'https://metro.legistar.com/MeetingDetail.aspx?ID=642118&GUID=F19B2133-928C-4390-9566-C293C61DC89A&Options=info&Search='}
+
+        mocker.patch('lametro.LametroEventScraper._merge_events', return_value=[(api_event, web_event)])
+        # TODO: mock the value of https://github.com/opencivicdata/python-legistar-scraper/blob/master/legistar/events.py#L195 with EventItems
+        mocker.patch('lametro.LametroEventScraper.agenda', return_value=[{}])
+
+        with pytest.raises(ValueError) as excinfo:
+            event_scraper.scrape()
+        
+        assert 'Agenda for Event {} has duplicate agenda items on the Legistar grid'\
+               .format(api_event['EventId'])\
+               in str(excinfo.value)

--- a/tests/lametro/test_events.py
+++ b/tests/lametro/test_events.py
@@ -35,6 +35,7 @@ def test_status_assignment(event_scraper,
 def test_sequence_duplicate_error(event_scraper,
                                   api_event, 
                                   web_event,
+                                  event_agenda_item,
                                   mocker):
     with requests_mock.Mocker() as m:
         matcher = re.compile('webapi.legistar.com')
@@ -47,12 +48,10 @@ def test_sequence_duplicate_error(event_scraper,
                                       'url': 'https://metro.legistar.com/MeetingDetail.aspx?ID=642118&GUID=F19B2133-928C-4390-9566-C293C61DC89A&Options=info&Search='}
 
         mocker.patch('lametro.LametroEventScraper._merge_events', return_value=[(api_event, web_event)])
-        # TODO: mock the value of https://github.com/opencivicdata/python-legistar-scraper/blob/master/legistar/events.py#L195 with EventItems
-        mocker.patch('lametro.LametroEventScraper.agenda', return_value=[{}])
+        mocker.patch('lametro.LametroEventScraper.agenda', return_value=[event_agenda_item, event_agenda_item])
 
         with pytest.raises(ValueError) as excinfo:
-            event_scraper.scrape()
-        
-        assert 'Agenda for Event {} has duplicate agenda items on the Legistar grid'\
-               .format(api_event['EventId'])\
-               in str(excinfo.value)
+            for event in event_scraper.scrape():
+                assert 'Agenda for Event {} has duplicate agenda items on the Legistar grid'\
+                       .format(api_event['EventId'])\
+                       in str(excinfo.value)

--- a/tests/lametro/test_events.py
+++ b/tests/lametro/test_events.py
@@ -32,10 +32,16 @@ def test_status_assignment(event_scraper,
         for event in event_scraper.scrape():
             assert event.status == scraper_assigned_status
 
+@pytest.mark.parametrize('item_sequence,should_error', [
+    (12, True),
+    (11, False),
+])
 def test_sequence_duplicate_error(event_scraper,
                                   api_event, 
                                   web_event,
                                   event_agenda_item,
+                                  item_sequence,
+                                  should_error,
                                   mocker):
     with requests_mock.Mocker() as m:
         matcher = re.compile('webapi.legistar.com')
@@ -44,14 +50,23 @@ def test_sequence_duplicate_error(event_scraper,
         matcher = re.compile('metro.legistar.com')
         m.get(matcher, json={}, status_code=200)
 
-        api_event['event_details'] = {'note': 'web', 
-                                      'url': 'https://metro.legistar.com/MeetingDetail.aspx?ID=642118&GUID=F19B2133-928C-4390-9566-C293C61DC89A&Options=info&Search='}
+        api_event['event_details'] = [{'note': 'web', 
+                                      'url': 'https://metro.legistar.com/MeetingDetail.aspx?ID=642118&GUID=F19B2133-928C-4390-9566-C293C61DC89A&Options=info&Search='}]
+        
+        event_agenda_item_b = event_agenda_item.copy()
+        event_agenda_item_b['EventItemAgendaSequence'] = item_sequence
 
         mocker.patch('lametro.LametroEventScraper._merge_events', return_value=[(api_event, web_event)])
-        mocker.patch('lametro.LametroEventScraper.agenda', return_value=[event_agenda_item, event_agenda_item])
+        mocker.patch('lametro.LametroEventScraper.agenda', return_value=[event_agenda_item, event_agenda_item_b])
 
-        with pytest.raises(ValueError) as excinfo:
+        if should_error:
+            with pytest.raises(ValueError) as excinfo:
+                for event in event_scraper.scrape():
+                    assert 'An agenda has duplicate agenda items on the Legistar grid'\
+                           .format(api_event['EventId'])\
+                           in str(excinfo.value)
+
+                    assert event['EventBodyName'] in str(excinfo.value)
+        else:
             for event in event_scraper.scrape():
-                assert 'Agenda for Event {} has duplicate agenda items on the Legistar grid'\
-                       .format(api_event['EventId'])\
-                       in str(excinfo.value)
+                assert len(event.agenda) == 2


### PR DESCRIPTION
This PR addresses https://github.com/datamade/la-metro-councilmatic/issues/337.

As the issue details, Legistar has – on at least one known occasion – duplicated the 'EventItemAgendaSequence'. This PR handles the problem by checking if an agenda has duplicate 'EventItemAgendaSequence', and if so, raising a ValueError with an instructive message to contact Metro. 

N.b., later on, we may implement a solution that flags problematic Events and, rather than raising an error, renders a message to Metro admin further downstream. 