### PR TITLE
Find matter_version_value and pass it into text

### DIFF
--- a/lametro/bills.py
+++ b/lametro/bills.py
@@ -292,7 +292,8 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
 
             bill.extras['local_classification'] = matter['MatterTypeName']
 
-            text = self.text(matter_id)
+            matter_version_value = matter['MatterVersion']
+            text = self.text(matter_id, matter_version_value)
 
             if text :
                 if text['MatterTextPlain'] :


### PR DESCRIPTION
This PR makes use of the optional `latest_version_value` arg in the newly devised `text` method: https://github.com/opencivicdata/python-legistar-scraper/pull/82/files

It relates to https://github.com/datamade/la-metro-councilmatic/issues/237