### PR TITLE
Handle "NO ACTION TAKEN" history item in LA Metro scraper

### DIFF
--- a/lametro/bills.py
+++ b/lametro/bills.py
@@ -320,7 +320,7 @@ ACTION_CLASSIFICATION = {'WITHDRAWN' : 'withdrawal',
                          'RECEIVED' : 'receipt',
                          'REFERRED' : 'referral-committee',
                          'FORWARDED DUE TO ABSENCES AND CONFLICTS' : 'committee-passage',
-                         'NO ACTION TAKEN': None}
+                         'NO ACTION TAKEN': 'filing'}
 
 BILL_TYPES = {'Contract' : None,
               'Budget' : None,

--- a/lametro/bills.py
+++ b/lametro/bills.py
@@ -319,7 +319,8 @@ ACTION_CLASSIFICATION = {'WITHDRAWN' : 'withdrawal',
                          'CARRIED OVER' : 'deferral',
                          'RECEIVED' : 'receipt',
                          'REFERRED' : 'referral-committee',
-                         'FORWARDED DUE TO ABSENCES AND CONFLICTS' : 'committee-passage'}
+                         'FORWARDED DUE TO ABSENCES AND CONFLICTS' : 'committee-passage',
+                         'NO ACTION TAKEN': None}
 
 BILL_TYPES = {'Contract' : None,
               'Budget' : None,


### PR DESCRIPTION
This PR adds a key for "NO ACTION TAKEN" to the `ACTION_CLASSIFICATION` dict.