### PR TITLE
Handle null vote options and end dates in the Chicago scrapers

### DIFF
--- a/chicago/bills.py
+++ b/chicago/bills.py
@@ -24,8 +24,7 @@ class ChicagoBillScraper(LegistarAPIBillScraper, Scraper):
     VOTE_OPTIONS = {'yea' : 'yes',
                     'rising vote' : 'yes',
                     'nay' : 'no',
-                    'recused' : 'excused',
-                    None: 'abstain'}
+                    'recused' : 'excused'}
 
     def session(self, action_date) :
         localize = pytz.timezone(self.TIMEZONE).localize
@@ -198,10 +197,7 @@ class ChicagoBillScraper(LegistarAPIBillScraper, Scraper):
                     vote_event.add_source(legistar_api + '/histories')
 
                     for vote in votes :
-                        try:
-                            raw_option = vote['VoteValueName'].lower()
-                        except AttributeError:
-                            raw_option = vote['VoteValueName']
+                        raw_option = vote['VoteValueName'].lower()
                         clean_option = self.VOTE_OPTIONS.get(raw_option,
                                                              raw_option)
                         vote_event.vote(clean_option, 

--- a/chicago/bills.py
+++ b/chicago/bills.py
@@ -24,7 +24,8 @@ class ChicagoBillScraper(LegistarAPIBillScraper, Scraper):
     VOTE_OPTIONS = {'yea' : 'yes',
                     'rising vote' : 'yes',
                     'nay' : 'no',
-                    'recused' : 'excused'}
+                    'recused' : 'excused',
+                    None: 'abstain'}
 
     def session(self, action_date) :
         localize = pytz.timezone(self.TIMEZONE).localize
@@ -185,7 +186,10 @@ class ChicagoBillScraper(LegistarAPIBillScraper, Scraper):
                     vote_event.add_source(legistar_api + '/histories')
 
                     for vote in votes :
-                        raw_option = vote['VoteValueName'].lower()
+                        try:
+                            raw_option = vote['VoteValueName'].lower()
+                        except AttributeError:
+                            raw_option = vote['VoteValueName']
                         clean_option = self.VOTE_OPTIONS.get(raw_option,
                                                              raw_option)
                         vote_event.vote(clean_option, 

--- a/chicago/bills.py
+++ b/chicago/bills.py
@@ -111,8 +111,8 @@ class ChicagoBillScraper(LegistarAPIBillScraper, Scraper):
                 if 'voice vote' in action_text.lower():
                     assert not any(v for v in self.votes(action['MatterHistoryId']) if v['VoteValueName'] is not None)
 
-                    print('Skipping votes for history {0} of matter ID {1}'.format(action['MatterHistoryId'],
-                                                                                   matter_id))
+                    self.info('Skipping votes for history {0} of matter ID {1}'.format(action['MatterHistoryId'],
+                                                                                       matter_id))
                     votes = (result, [])
                 else:
                     votes = (result, self.votes(action['MatterHistoryId']))

--- a/chicago/people.py
+++ b/chicago/people.py
@@ -117,12 +117,14 @@ class ChicagoPersonScraper(LegistarAPIPersonScraper, Scraper):
 
                         members[person] = p
 
+                    try:
+                        end_date = self.toDate(office['OfficeRecordEndDate'])
+                    except TypeError:
+                        end_date = ''
                     p.add_membership(body['BodyName'],
                                      role=role,
-                                     start_date = self.toDate(office['OfficeRecordStartDate']),
-                        
-                                     end_date = self.toDate(office['OfficeRecordEndDate']))
-                        
+                                     start_date=self.toDate(office['OfficeRecordStartDate']),
+                                     end_date=end_date)
 
                 yield o
 


### PR DESCRIPTION
The Chicago scrapers have been failing to due to unexpected null values. This PR addresses that.