### PR TITLE
Accept skipping absent voice votes

### DIFF
--- a/chicago/bills.py
+++ b/chicago/bills.py
@@ -109,7 +109,7 @@ class ChicagoBillScraper(LegistarAPIBillScraper, Scraper):
                 action_text = action['MatterHistoryActionText'] or ''
 
                 if 'voice vote' in action_text.lower():
-                    assert not any(v for v in self.votes(action['MatterHistoryId']) if v['VoteValueName'] is not None)
+                    assert not any(v for v in self.votes(action['MatterHistoryId']) if v['VoteValueName'] not in (None, 'Absent'))
 
                     self.info('Skipping votes for history {0} of matter ID {1}'.format(action['MatterHistoryId'],
                                                                                        matter_id))


### PR DESCRIPTION
Sometimes, Chicago logs absence in voice votes, e.g., http://webapi.legistar.com/v1/chicago/eventitems/359570/votes.

This PR updates the voice vote logic to accept skipping those votes.