### PR TITLE
LA Metro: Removing time as a necessity for partnering English/Spanish events

### DIFF
--- a/lametro/events.py
+++ b/lametro/events.py
@@ -114,7 +114,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
             if web_event.has_audio:
                 event_audio.append(web_event['Audio'])
 
-            matches = spanish_events.get(event.partner_key, None)
+            matches = spanish_events.pop(event.partner_key, None)
 
             if matches:
                 spanish_event, spanish_web_event = matches
@@ -155,7 +155,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
             else:
                 event_name = body_name
 
-            # Events can have an EventAgendaStatusName of "Final", "Final Revised", 
+            # Events can have an EventAgendaStatusName of "Final", "Final Revised",
             # and "Final 2nd Revised."
             # We classify these events as "passed."
             status_name = event['EventAgendaStatusName']
@@ -209,7 +209,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                         note = "Agenda number, {}".format(item["EventItemAgendaNumber"])
                         agenda_item['notes'].append(note)
 
-                    # The EventItemAgendaSequence provides 
+                    # The EventItemAgendaSequence provides
                     # the line number of the Legistar agenda grid.
                     agenda_item['extras']['item_agenda_sequence'] = item['EventItemAgendaSequence']
 
@@ -222,7 +222,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                         {event_name} on {event_date} ({legistar_api_url}). \
                         Contact Metro, and ask them to remove the duplicate EventItemAgendaSequence.'
 
-                    raise ValueError(error_msg.format(event_name=e.name, 
+                    raise ValueError(error_msg.format(event_name=e.name,
                                                       event_date=e.start_date.strftime("%B %d, %Y"),
                                                       legistar_api_url=legistar_api_url))
 
@@ -329,11 +329,11 @@ class LAMetroAPIEvent(dict):
 
     @property
     def partner_key(self):
-        return (self._partner_name, self['EventDate'], self['EventTime'])
+        return (self._partner_name, self['EventDate'])
 
     @property
     def key(self):
-        return (self['EventBodyName'], self['EventDate'], self['EventTime'])
+        return (self['EventBodyName'], self['EventDate'])
 
 
 class LAMetroWebEvent(dict):

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -98,7 +98,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
 
             if event.is_spanish:
                 try:
-                    assert spanish_events.get(event.key, None) == None
+                    ssert event.key not in spanish_events
                 except AssertionError:
                     raise AssertionError('{0} already exists as a key with a value of {1}'.format(event.key, spanish_events[event.key]))
                 spanish_events[event.key] = (event, web_event)

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -98,7 +98,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
 
             if event.is_spanish:
                 try:
-                    ssert event.key not in spanish_events
+                    assert event.key not in spanish_events
                 except AssertionError:
                     raise AssertionError('{0} already exists as a key with a value of {1}'.format(event.key, spanish_events[event.key]))
                 spanish_events[event.key] = (event, web_event)

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -97,6 +97,10 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
             web_event = LAMetroWebEvent(web_event)
 
             if event.is_spanish:
+                try:
+                    assert spanish_events.get(event.key, None) == None
+                except AssertionError:
+                    raise AssertionError('{0} already exists as a key with a value of {1}'.format(event.key, spanish_events[event.key]))
                 spanish_events[event.key] = (event, web_event)
             else:
                 english_events.append((event, web_event))


### PR DESCRIPTION
Per https://github.com/datamade/la-metro-councilmatic/issues/393#issuecomment-507776469, Spanish and English events will always occur at the same time. Therefore, the keys we use to match the events are sufficient if they contain the committee name and date of meeting. 

This PR removes the event time as a part of the `partner_key` and `key`.