### PR TITLE
LA Metro: adding in Vice Chair as a position

### DIFF
--- a/lametro/__init__.py
+++ b/lametro/__init__.py
@@ -67,7 +67,7 @@ class Lametro(Jurisdiction):
 
         org.add_post('Chair', 'Chair')
 
-        org.add_post('Vice Chair', '1st Vice Chair')
+        org.add_post('Vice Chair', 'Vice Chair')
 
         org.add_post('1st Vice Chair', '1st Vice Chair')
 

--- a/lametro/__init__.py
+++ b/lametro/__init__.py
@@ -67,6 +67,8 @@ class Lametro(Jurisdiction):
 
         org.add_post('Chair', 'Chair')
 
+        org.add_post('Vice Chair', '1st Vice Chair')
+
         org.add_post('1st Vice Chair', '1st Vice Chair')
 
         org.add_post('2nd Vice Chair', '2nd Vice Chair')


### PR DESCRIPTION
It looks like [Eric Garcetti is listed as "Vice Chair"](https://metro.legistar.com/PersonDetail.aspx?ID=144844&GUID=A840E600-58F9-43DC-8E71-C54334C73C25&Search=) and that is causing the scraper to break. We don't have a Vice Chair role set, just 1st Vice Chair and 2nd Vice Chair.

This adds in "Vice Chair" as a position until we learn whether it should resolve to a different position.