### PR TITLE
[LAMetro] Swapping MatterIntroDate for MatterAgendaDate

### DIFF
--- a/lametro/bills.py
+++ b/lametro/bills.py
@@ -11,6 +11,8 @@ from legistar.bills import LegistarBillScraper, LegistarAPIBillScraper
 
 from .secrets import TOKEN
 
+LOGGER = logging.getLogger(__name__)
+
 class LametroBillScraper(LegistarAPIBillScraper, Scraper):
     BASE_URL = 'https://webapi.legistar.com/v1/metro'
     BASE_WEB_URL = 'https://metro.legistar.com'
@@ -276,7 +278,10 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
                 except scrapelib.HTTPError:
                     continue
                 else:
-                    date = related_bill['MatterIntroDate']
+                    try:
+                        date = related_bill['MatterAgendaDate']
+                    except AttributeError:
+                        raise AttributeError('Bill with MatterId {} has no MatterAgendaDate'.(matter_id))
                     related_bill_session = self.session(self.toTime(date))
                     identifier = related_bill['MatterFile']
                     bill.add_related_bill(identifier=identifier,


### PR DESCRIPTION
As https://github.com/datamade/la-metro-councilmatic/issues/370 documents, `MatterIntroDate` refers to the date the bill is created in Insite, while `MatterAgendaDate` refers to the first time a bill is introduced on an agenda. This PR reassigns the field we draw the fiscal year information from to be `MatterAgendaDate`, so we can display the correct fiscal year.

I had the scraper throw an error in order to be brittle, so we know if our assumption of every bill having a `MatterAgendaDate` doesn't pan out. In the issue it was expressed this would be better than assigning with `MatterIntroDate` in the case there wasn't a `MatterAgendaDate`.