### PR TITLE
Add method to strip extra whitespace from NYC event locations

### DIFF
--- a/nyc/events.py
+++ b/nyc/events.py
@@ -23,10 +23,11 @@ class NYCEventsScraper(LegistarAPIEventScraperZip, Scraper):
 
     def scrape(self, window=3):
         n_days_ago = datetime.datetime.utcnow() - datetime.timedelta(float(window))
+
         for api_event, event in self.events(n_days_ago):
 
             when = api_event['start']
-            location = api_event['EventLocation']
+            location = self._clean_location(api_event['EventLocation'])
 
             description = event['Meeting\xa0Topic']
 
@@ -107,6 +108,9 @@ class NYCEventsScraper(LegistarAPIEventScraperZip, Scraper):
                     e.add_source(detail_url, note='web')
 
             yield e
+
+    def _clean_location(self, location_string):
+        return re.sub(r'\s{2,}', ' ', location_string)
 
     def _parse_location(self, location_string):
         other_orgs = None


### PR DESCRIPTION
NYC event imports were failing with this traceback:

```
Traceback (most recent call last):
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/django/db/models/query.py", line 486, in get_or_create
    return self.get(**lookup), False
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/django/db/models/query.py", line 399, in get
    self.model._meta.object_name
opencivicdata.legislative.models.event.EventLocation.DoesNotExist: EventLocation matching query does not exist.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/django/db/backends/utils.py", line 85, in _execute
    return self.cursor.execute(sql, params)
psycopg2.errors.StringDataRightTruncation: value too long for type character varying(200)


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/bin/pupa", line 10, in <module>
    sys.exit(main())
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/pupa/cli/__main__.py", line 68, in main
    subcommands[args.subcommand].handle(args, other)
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/pupa/cli/commands/update.py", line 260, in handle
    return self.do_handle(args, other, juris)
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/pupa/cli/commands/update.py", line 307, in do_handle
    report['import'] = self.do_import(juris, args)
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/pupa/cli/commands/update.py", line 215, in do_import
    report.update(event_importer.import_directory(datadir))
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/pupa/importers/base.py", line 196, in import_directory
    return self.import_data(json_stream())
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/pupa/importers/base.py", line 233, in import_data
    obj_id, what = self.import_item(data)
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/pupa/importers/base.py", line 254, in import_item
    data = self.prepare_for_db(data)
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/pupa/importers/events.py", line 66, in prepare_for_db
    data['location'] = self.get_location(data['location'])
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/pupa/importers/events.py", line 60, in get_location
    jurisdiction_id=self.jurisdiction_id)
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/django/db/models/manager.py", line 82, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/django/db/models/query.py", line 488, in get_or_create
    return self._create_object_from_params(lookup, params)
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/django/db/models/query.py", line 522, in _create_object_from_params
    obj = self.create(**params)
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/django/db/models/query.py", line 413, in create
    obj.save(force_insert=True, using=self.db)
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/django/db/models/base.py", line 718, in save
    force_update=force_update, update_fields=update_fields)
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/django/db/models/base.py", line 748, in save_base
    updated = self._save_table(raw, cls, force_insert, force_update, using, update_fields)
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/django/db/models/base.py", line 831, in _save_table
    result = self._do_insert(cls._base_manager, using, fields, update_pk, raw)
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/django/db/models/base.py", line 869, in _do_insert
    using=using, raw=raw)
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/django/db/models/manager.py", line 82, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/django/db/models/query.py", line 1136, in _insert
    return query.get_compiler(using=using).execute_sql(return_id)
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1289, in execute_sql
    cursor.execute(sql, params)
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/django/db/backends/utils.py", line 68, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/django/db/backends/utils.py", line 77, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/django/db/backends/utils.py", line 85, in _execute
    return self.cursor.execute(sql, params)
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/Users/hannah/.virtualenvs/scrapers-us-municipal/lib/python3.7/site-packages/django/db/backends/utils.py", line 85, in _execute
    return self.cursor.execute(sql, params)
django.db.utils.DataError: value too long for type character varying(200)
```

The failing value was `'Location:  The City College of New York\r\n                  NAC Ballroom, Ground Floor\r\n                  North Academic Center Building (NAC)\r\n                  160 Convent Avenue (@ 138th street)\r\n                  New York, N.Y  10031'`, so I added a method to the NYC event scraper to collapse redundant whitespace in location names.