### PR TITLE
only allow one set of mintues to be added

### DIFF
--- a/lametro/events.py
+++ b/lametro/events.py
@@ -279,7 +279,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                                url=event['EventMinutesFile'],
                                media_type="application/pdf")
 
-            if web_event['Published minutes'] != 'Not\xa0available':
+            elif web_event['Published minutes'] != 'Not\xa0available':
                 e.add_document(note=web_event['Published minutes']['label'],
                                url=web_event['Published minutes']['url'],
                                media_type="application/pdf")


### PR DESCRIPTION
This event had duplicated minutes because they appeared in the API on the detail page.

- http://webapi.legistar.com/v1/metro/events/1169
- https://metro.legistar.com/MeetingDetail.aspx?ID=493213&GUID=CDB198B6-DE4C-4EBB-88A6-946F93F07991&Options=info&Search=

The minutes url pointed to the same doc. This broke the councilmatic expectation that there were only one set of minutes, preventing the meeting from showing up.

https://sentry.io/organizations/datamade/issues/1316778912/?project=137567&referrer=slack