### PR TITLE
Upgrades to the LA Metro scraper

### DIFF
--- a/lametro/events.py
+++ b/lametro/events.py
@@ -246,11 +246,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                         note = "Agenda number, {}".format(agenda_number)
                         agenda_item['notes'].append(note)
 
-                        try:
-                            agenda_item['extras']['agenda_number'] = int(float(agenda_number))
-                        except ValueError:
-                            import pdb
-                            pdb.set_trace()
+                        agenda_item['extras']['agenda_number'] = agenda_number
 
                     # The EventItemAgendaSequence provides
                     # the line number of the Legistar agenda grid.

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -283,6 +283,12 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                 e.add_document(note=web_event['Published minutes']['label'],
                                url=web_event['Published minutes']['url'],
                                media_type="application/pdf")
+            else:
+                approved_minutes = self.find_approved_minutes(event)
+                if approved_minutes:
+                    e.add_document(note=approved_minutes['MatterAttachmentName'],
+                                   url=approved_minutes['MatterAttachmentHyperlink'],
+                                   media_type="application/pdf")
 
             for audio in event['audio']:
                 try:
@@ -342,6 +348,66 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
 
             if suppress:
                 item['EventItemMatterFile'] = None
+
+    def find_approved_minutes(self, event):
+        '''
+        The minutes of some meetings are available as a legislative item
+        that are approved at the subsequent meeting. This method tries
+        to find them.
+
+        This method is pretty complicated, but if we can get it right
+        here, it avoids many complicated and expensive queries in the
+        councilmatic app.
+
+        '''
+        name = event['EventBodyName']
+
+        if name not in {'Board of Directors - Regular Board Meeting',
+                        'LA SAFE'}
+            return None
+
+        # if the event is the future, there won't have been a chance to
+        # approve the minutes
+        if event['start'] > datetime.datetime.now(datetime.timezone.utc):
+            return None
+
+        date = event['start'].strftime('%B %-d, %Y')
+        result = self.search(
+            '/matters/',
+            'MatterId',
+            "MatterBodyId eq {} and substringof('{}', MatterTitle) and substringof('Minutes', MatterTitle)".format(event['EventBodyId'], date))
+
+        try:
+            matter, = result
+        except ValueError as e:
+            if 'not enough values' in str(e):
+                self.warning(
+                    "Couldn't find minutes for the {} meeting of {}."\
+                        .format(name, date))
+                return None
+            else:
+                raise
+
+        attachment_url = self.BASE_URL + '/matters/{}/attachments'.format(matter['MatterId'])
+
+
+        attachments = self.get(attachment_url).json()
+
+        if len(attachments) == 0:
+            raise ValueError('No attachments for the approved minutes matter')
+        elif len(attachments) == 1:
+            return attachments[0]
+        else:
+            # this meeting had both special and regular board meeting
+            # attached to the minutes matter
+            if date == 'May 28, 2015':
+                attachment_name = 'Regular Board Meeting Minutes on May 28, 2015'
+                attachment, = [each for each in attachments
+                               if each['MatterAttachmentName'] == attachment_name]
+                return attachment
+            else:
+                raise ValueError("More than one attachement for the approved minutes matter")
+
 
 
 class LAMetroAPIEvent(dict):

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -278,8 +278,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                 e.add_document(note='Minutes',
                                url=event['EventMinutesFile'],
                                media_type="application/pdf")
-
-            if web_event['Published minutes'] != 'Not\xa0available':
+            elif web_event['Published minutes'] != 'Not\xa0available':
                 e.add_document(note=web_event['Published minutes']['label'],
                                url=web_event['Published minutes']['url'],
                                media_type="application/pdf")

--- a/lametro/people.py
+++ b/lametro/people.py
@@ -65,6 +65,8 @@ class LametroPersonScraper(LegistarAPIPersonScraper, Scraper):
         members = {}
         for member, offices in terms.items():
             p = Person(member)
+            p.family_name = office['OfficeRecordLastName']
+            p.given_name=office['OfficeRecordFirstName']
             for term in offices:
                 role = term['OfficeRecordTitle']
 
@@ -98,6 +100,9 @@ class LametroPersonScraper(LegistarAPIPersonScraper, Scraper):
             person_api_url, person_web_url = source_urls
             p.add_source(person_api_url, note='api')
             p.add_source(person_web_url, note='web')
+            p.family_name = term['OfficeRecordLastName']
+            p.given_name = term['OfficeRecordFirstName']
+
 
             members[member] = p
 

--- a/lametro/people.py
+++ b/lametro/people.py
@@ -65,6 +65,7 @@ class LametroPersonScraper(LegistarAPIPersonScraper, Scraper):
         members = {}
         for member, offices in terms.items():
             p = Person(member)
+
             p.family_name = office['OfficeRecordLastName']
             p.given_name = office['OfficeRecordFirstName']
 
@@ -104,9 +105,6 @@ class LametroPersonScraper(LegistarAPIPersonScraper, Scraper):
 
             p.add_source(person_api_url, note='api')
             p.add_source(person_web_url, note='web')
-
-            p.family_name = term['OfficeRecordLastName']
-            p.given_name = term['OfficeRecordFirstName']
 
             members[member] = p
 

--- a/lametro/people.py
+++ b/lametro/people.py
@@ -66,7 +66,8 @@ class LametroPersonScraper(LegistarAPIPersonScraper, Scraper):
         for member, offices in terms.items():
             p = Person(member)
             p.family_name = office['OfficeRecordLastName']
-            p.given_name=office['OfficeRecordFirstName']
+            p.given_name = office['OfficeRecordFirstName']
+
             for term in offices:
                 role = term['OfficeRecordTitle']
 
@@ -76,6 +77,7 @@ class LametroPersonScraper(LegistarAPIPersonScraper, Scraper):
                                start_date = self.toDate(term['OfficeRecordStartDate']),
                                end_date = self.toDate(term['OfficeRecordEndDate']),
                                appointment = True)
+
                 if role != 'Chief Executive Officer':
                     if role == 'non-voting member':
                         member_type = 'Nonvoting Board Member'
@@ -93,16 +95,18 @@ class LametroPersonScraper(LegistarAPIPersonScraper, Scraper):
                                end_date = end_date)
 
                     acting_member_end_date = ACTING_MEMBERS_WITH_END_DATE.get(p.name)
+
                     if acting_member_end_date and acting_member_end_date <= end_date:
                         board_membership.extras = {'acting': 'true'}
 
             source_urls = self.person_sources_from_office(term)
             person_api_url, person_web_url = source_urls
+
             p.add_source(person_api_url, note='api')
             p.add_source(person_web_url, note='web')
+
             p.family_name = term['OfficeRecordLastName']
             p.given_name = term['OfficeRecordFirstName']
-
 
             members[member] = p
 


### PR DESCRIPTION
This PR makes changes to the LA Metro scraper to try to handle in the data layer issues that had been handled in Metro's Councilmatic view code. Most significantly:

1. trying to find at attach minutes to meetings
2. attaching family name to person (which we'll use for sorting)
3. agenda_numbers to extras for sorting