### PR TITLE
Import oversight committees

### DIFF
--- a/lametro/people.py
+++ b/lametro/people.py
@@ -102,7 +102,7 @@ class LametroPersonScraper(LegistarAPIPersonScraper, Scraper):
             members[member] = p
 
         for body in self.bodies():
-            if body['BodyTypeId'] == body_types['Committee']:
+            if body['BodyTypeId'] in (body_types['Committee'], body_types['Independent Taxpayer Oversight Committee']):
                 organization_name = body['BodyName'].strip()
                 o = Organization(organization_name,
                                  classification='committee',


### PR DESCRIPTION
## Description

Closes #295.

This PR makes a small change to import Metro's taxpayer oversight committees.

## Testing instructions

- Import people: `pupa update lametro people --rpm=0`
- Import events: `pupa update lametro events --rpm=0`
- Shell into your database, e.g., `psql opencivicdata`. (May vary, if your database is called something else or if you need to set additional connection parameters.)
- Confirm that there are oversight committees in your organization table: `select id, name from opencivicdata_organization where jurisdiction_id = 'ocd-jurisdiction/country:us/state:ca/county:los_angeles/transit_authority';`
- Grab the ID of the Measure M Taxpayer Oversight Committee and substitute it into the following query to confirm events have been imported: `select e.id, e.name, e.start_date from opencivicdata_event as e join opencivicdata_eventparticipant as ep on e.id = ep.event_id join opencivicdata_organization as o on ep.organization_id = o.id where o.id = '<INSERT ID HERE>';`
