### PR TITLE
Pin opencivicdata to < 3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-https://github.com/opencivicdata/python-opencivicdata-django/zipball/master
+https://github.com/opencivicdata/python-opencivicdata-django/archive/2.5.0.zip
 pupa==0.9.0
 https://github.com/opencivicdata/python-legistar-scraper/zipball/master
 lxml
-sh 
+sh
 pytest==4.2.0
 pytest-mock==1.10.1
 requests-mock==1.5.2


### PR DESCRIPTION
## Description

`opencivicdata` introduced some breaking changes in 3.0. This PR pins it to [the last non-breaking release](https://github.com/opencivicdata/python-opencivicdata/releases/tag/2.5.0). 

The downside of this approach is we'll need to bump this requirement if there are any updates in the 2.x series, which is a departure from our previous practice of installing from master, however given the relative stability/infrequent release history of the OCD code base, I think this should be OK. Plus it ensures that we only upgrade `opencivicdata` when we we're ready to!