### PR TITLE
Don't allow unpaired events to be overwritten

### DIFF
--- a/lametro/events.py
+++ b/lametro/events.py
@@ -39,6 +39,12 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
             try:
                 partner_event = unpaired_events[incoming_event.partner_key]
             except KeyError:
+                if incoming_event.key in unpaired_events:
+                    raise ValueError(
+                        '{0} already exists as a key with a value of {1}'.format(incoming_event.key,
+                                                                                 unpaired_events[incoming_event.key])
+                    )
+
                 unpaired_events[incoming_event.key] = incoming_event
 
             else:


### PR DESCRIPTION
## Description

In the same vein as https://github.com/opencivicdata/scrapers-us-municipal/pull/309#discussion_r366466433, this PR raises an exception if there are event key collisions when aggregating unpaired events. This exception indicates that there is more than one event on a given day for a given meeting body, which violates our expectations of how the data should look.

## Note

There are some test events in Legistar that will break the scraper with this change. We need to work with Metro to remove them before we merge.