### PR TITLE
Metro: Don't scrape service council events

### DIFF
--- a/lametro/events.py
+++ b/lametro/events.py
@@ -199,6 +199,9 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                 body_name, event_name = [part.strip()
                                          for part
                                          in body_name.split('-')]
+            elif body_name.endswith('Service Council'):
+                # Don't scrape service council events.
+                continue
             else:
                 event_name = body_name
 


### PR DESCRIPTION
## Description

Starting next week, LA Metro will be inputting service council events into Legistar. These are distinct from the governing board/committees, so they don't wish to include them in their instance of Councilmatic. This PR adds a line to the event scrape to omit service council meetings.

Connects https://github.com/datamade/la-metro-councilmatic/issues/606