### PR TITLE
Strip leading and trailing whitespace from links

### DIFF
--- a/lametro/bills.py
+++ b/lametro/bills.py
@@ -292,7 +292,7 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
             for attachment in self.attachments(matter_id) :
                 if attachment['MatterAttachmentName'] :
                     bill.add_document_link(attachment['MatterAttachmentName'],
-                                           attachment['MatterAttachmentHyperlink'],
+                                           attachment['MatterAttachmentHyperlink'].strip(),
                                            media_type="application/pdf")
 
             bill.extras['local_classification'] = matter['MatterTypeName']


### PR DESCRIPTION
### Description

This PR strips leading and trailing whitespace from attachment links, as they cause validation and thus the scrape to fail: 

```
ScrapeValueError: validation of Bill cb909502-c6a4-11ea-b792-0242ac110002 failed: 
	'http://libraryarchives.metro.net/DB_Attachments/151106_Attachment_A_Addendum_FEIR_with_Appendices.pdf ' is not a 'uri'

Failed validating 'format' in schema['properties']['documents']['items']['properties']['links']['items']['properties']['url']:
    {'format': 'uri', 'type': 'string'}

On instance['documents'][0]['links'][0]['url']:
    'http://libraryarchives.metro.net/DB_Attachments/151106_Attachment_A_Addendum_FEIR_with_Appendices.pdf '
  File "bin/pupa", line 8, in <module>
    sys.exit(main())
  File "pupa/cli/__main__.py", line 68, in main
    subcommands[args.subcommand].handle(args, other)
  File "pupa/cli/commands/update.py", line 278, in handle
    return self.do_handle(args, other, juris)
  File "pupa/cli/commands/update.py", line 327, in do_handle
    report['scrape'] = self.do_scrape(juris, args, scrapers)
  File "pupa/cli/commands/update.py", line 175, in do_scrape
    report[scraper_name] = scraper.do_scrape(**scrape_args)
  File "pupa/scrape/base.py", line 119, in do_scrape
    self.save_object(obj)
  File "pupa/scrape/base.py", line 102, in save_object
    raise ve
  File "pupa/scrape/base.py", line 99, in save_object
    obj.validate()
  File "pupa/scrape/base.py", line 202, in validate
    self.__class__.__name__, self._id, '\n\t'+'\n\t'.join(errors)
```

Sentry: https://sentry.io/organizations/datamade/issues/1605194328

### Testing instructions

- Pull down and check out this branch.
- Run a small, fast bill scrape and confirm that nothing breaks: `pupa update lametro bills --rpm=0 window=3`