### PR TITLE
Metro: Skip service council public hearings

### DIFF
--- a/lametro/events.py
+++ b/lametro/events.py
@@ -199,8 +199,8 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                 body_name, event_name = [part.strip()
                                          for part
                                          in body_name.split('-')]
-            elif body_name.endswith('Service Council'):
-                # Don't scrape service council events.
+            elif body_name.endswith('Service Council') or body_name.endswith('Service Council Public Hearing'):
+                # Don't scrape service council or service council public hearing events.
                 continue
             else:
                 event_name = body_name


### PR DESCRIPTION
### Description

Similarly to #319, this PR adds logic to skip service council public hearings. I went this route, rather than skipping any meeting of a body containing "Service Council" because I figured the specificity would be more future-proof. 

Handles https://github.com/datamade/la-metro-councilmatic/issues/634.