### PR TITLE
Metro: Use body type to skip service council and service council public hearing events

### DIFF
--- a/lametro/events.py
+++ b/lametro/events.py
@@ -192,6 +192,10 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
 
         events = self.events(since_datetime=n_days_ago)
 
+        service_councils = set(
+            sc['BodyId'] for sc in self.search('/bodies/', 'BodyId', 'BodyTypeId eq 70 or BodyTypeId eq 75')
+        )
+
         for event, web_event in self._merge_events(events):
             body_name = event["EventBodyName"]
 
@@ -199,8 +203,9 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                 body_name, event_name = [part.strip()
                                          for part
                                          in body_name.split('-')]
-            elif body_name.endswith('Service Council') or body_name.endswith('Service Council Public Hearing'):
+            elif event['EventBodyId'] in service_councils:
                 # Don't scrape service council or service council public hearing events.
+                self.info('Skipping event {0} for {1}'.format(event['EventId'], event['EventBodyName']))
                 continue
             else:
                 event_name = body_name

--- a/lametro/people.py
+++ b/lametro/people.py
@@ -135,7 +135,6 @@ class LametroPersonScraper(LegistarAPIPersonScraper, Scraper):
                 for office in self.body_offices(body):
                     role = office['OfficeRecordTitle']
 
-
                     if role not in ("Chair", "Vice Chair", "Chief Executive Officer"):
                         if role == 'non-voting member':
                             role = 'Nonvoting Member'


### PR DESCRIPTION
Surprise! Data entry isn't always consistent. This PR adds an extra search to grab the IDs of all bodies of the Service Council (70) or Service Council Public Hearing (75) body type, and skips any meetings of those bodies, rather than trying to pattern match the name.

Handles https://github.com/datamade/la-metro-councilmatic/issues/606, https://github.com/datamade/la-metro-councilmatic/issues/634.