### PR TITLE
LA Metro: Skip attachments that are not visible in the web interface

### DIFF
--- a/lametro/bills.py
+++ b/lametro/bills.py
@@ -57,6 +57,9 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
         else:
             return False
 
+    def _show_attachment(self, attachment):
+        return attachment['MatterAttachmentShowOnInternetPage']
+
     def session(self, action_date) :
         from . import Lametro
 
@@ -290,7 +293,7 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
                                    media_type="application/pdf")
 
             for attachment in self.attachments(matter_id) :
-                if attachment['MatterAttachmentName'] :
+                if attachment['MatterAttachmentName'] and self._show_attachment(attachment):
                     bill.add_document_link(attachment['MatterAttachmentName'],
                                            attachment['MatterAttachmentHyperlink'].strip(),
                                            media_type="application/pdf")


### PR DESCRIPTION
This PR adds Logic to the Metro bill scraper to skip attachments if `MatterAttachmentShowOnInternetPage` is False. It would probably be ideal to handle this similarly to the way we do bills, i.e., scrape a record of the attachment but don't scrape any metadata or show in the user interface, but there is an immediate need to suppress an attachment on the live site, and this is the fastest way to achieve it, for now.

## Testing instructions

- Scrape a bill with a suppressed attachment and confirm that the output does not have any related documents: `pupa update --scrape lametro bills matter_ids=7212`