### PR TITLE
do full scrape if window is '0'

### DIFF
--- a/lametro/events.py
+++ b/lametro/events.py
@@ -185,7 +185,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
         return english_events
 
     def scrape(self, window=None) :
-        if window:
+        if window and float(window):
             n_days_ago = datetime.datetime.utcnow() - datetime.timedelta(float(window))
         else:
             n_days_ago = None

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -185,7 +185,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
         return english_events
 
     def scrape(self, window=None) :
-        if window and float(window):
+        if window and float(window) != 0:
             n_days_ago = datetime.datetime.utcnow() - datetime.timedelta(float(window))
         else:
             n_days_ago = None


### PR DESCRIPTION
this gives same behavior as setting a windows to '0' for event scraper.

not having this caused us to miss events when we turned of nightly full scrapes