### PR TITLE
Skip committee memberships for pre-determined list of people

### DIFF
--- a/lametro/people.py
+++ b/lametro/people.py
@@ -38,6 +38,10 @@ BOARD_OFFICE_ROLES = ("Chair",
                       "2nd Vice Chair",
                       "Chief Executive Officer")
 
+PENDING_COMMITTEE_MEMBERS = (
+    'Holly Mitchell',
+)
+
 
 class LametroPersonScraper(LegistarAPIPersonScraper, Scraper):
     BASE_URL = 'http://webapi.legistar.com/v1/metro'
@@ -150,6 +154,13 @@ class LametroPersonScraper(LegistarAPIPersonScraper, Scraper):
                             role = 'Member'
 
                     person = office['OfficeRecordFullName']
+
+                    # Temporarily skip committee memberships, e.g., for
+                    # new board members. The content of this array is provided
+                    # by Metro.
+                    if person in PENDING_COMMITTEE_MEMBERS:
+                        self.warning('Skipping {0} membership for {1}'.format(organization_name, person))
+                        continue
 
                     if person in members:
                         p = members[person]


### PR DESCRIPTION
## Description

Metro wants to hold committee memberships for Holly Mitchell until they are announced. This PR adds logic to skip committee memberships for an arbitrary list of people.

## Testing instructions

- Run `pupa update --scrape lametro people --rpm=0` and confirm that you see two log messages indicating Holly Mitchell's committee memberships are being skipped.
- Grep the `_data/` directory and confirm Mitchell herself, as well as her board membership, has been scraped.