### PR TITLE
Metro: Add Tim Sandoval

### DIFF
--- a/lametro/people.py
+++ b/lametro/people.py
@@ -23,7 +23,8 @@ VOTING_POSTS = {'Jacquelyn Dupont-Walker' : 'Appointee of Mayor of the City of L
                 'Ara Najarian' : 'Appointee of Los Angeles County City Selection Committee, North County/San Fernando Valley sector',
                 'Robert Garcia' : 'Appointee of Los Angeles County City Selection Committee, Southeast Long Beach sector',
                 'Don Knabe' : 'Los Angeles County Board Supervisor, District 4',
-                'Michael Antonovich' : 'Los Angeles County Board Supervisor, District 5'}
+                'Michael Antonovich' : 'Los Angeles County Board Supervisor, District 5',
+                'Tim Sandoval': 'Appointee of Los Angeles County City Selection Committee, San Gabriel Valley sector'}
 
 NONVOTING_POSTS = {'Carrie Bowen' : 'Appointee of Governor of California',
                    'Shirley Choate' : 'District 7 Director, California Department of Transportation (Caltrans), Appointee of the Governor of California',


### PR DESCRIPTION
## Description

This PR adds information about Tim Sandoval's post to the `VOTING_POSTS` object. Connects https://github.com/datamade/la-metro-councilmatic/issues/693.