### PR TITLE
Update Dockerfile, add Docker Compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,20 @@
-FROM        sunlightlabs/pupa:latest
-MAINTAINER  Paul R. Tagliamonte <paultag@sunlightfoundation.com>
+FROM python:3.6-slim-stretch
+LABEL maintainer "DataMade <info@datamade.us>"
 
-RUN mkdir -p /opt/sunlightfoundation.com/
-ADD . /opt/sunlightfoundation.com/scrapers-us-municipal/
-RUN echo "deb-src http://debian.lcs.mit.edu/debian/ unstable main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get build-dep python3-lxml -y
-RUN pip3 install lxml
-RUN pip3 install -r /opt/sunlightfoundation.com/scrapers-us-municipal/requirements.txt
+ENV PYTHONUNBUFFERED=1
 
-RUN echo "/opt/sunlightfoundation.com/scrapers-us-municipal/" > /usr/lib/python3/dist-packages/scrapers-us-municipal.pth
+RUN apt-get update && \
+    apt-get install -y libxml2-dev gdal-bin && \
+    apt-get clean && \
+    rm -rf /var/cache/apt/* /var/lib/apt/lists/*
+
+RUN mkdir /src
+WORKDIR /src
+
+COPY ./requirements.txt /src/requirements.txt
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
+
+COPY . /src
+
+ENTRYPOINT ["/src/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,21 +1,32 @@
-municipal-scrapers
-==================
+scrapers-us-municipal
+=====================
 
-source for municipal scrapers
+Source for municipal scrapers
 
 To find out more about the ins and outs of these scrapers, as well as how to create your own, head on over to [docs.opencivicdata.org's scraping page](http://docs.opencivicdata.org/en/latest/scrape/index.html).
 
 Issues?
 -------
 
-Issues with the data coming from these scrapers should be filed at the [OCD Data issue tracker](https://sunlight.atlassian.net/browse/DATA/)
-
-All Open Civic Data issues can be browsed and filed at [the Open Civic Data JIRA instance](https://sunlight.atlassian.net/browse/OCD/).
+Issues with the data coming from these scrapers should be filed [in this repository](https://github.com/opencivicdata/scrapers-us-municipal/issues).
 
 ## Development
-Requires python3, postgresql
 
-### Initialization
+### With Docker
+
+Requires Docker and Docker Compose
+
+#### Initialization
+
+```bash
+docker-compose run --rm scrapers pupa init YOUR_CITY_SCRAPER
+```
+
+### Without Docker
+
+Requires Python 3, PostGIS
+
+#### Initialization
 Assuming that you want to have your database be called `opencivicdata` on your local machine
 
 ```bash
@@ -45,8 +56,17 @@ django-admin makemigrations
 django-admin migrate
 ```
 
-### Testing
-Before submitting a PR, please run `pupa update YOUR_CITY_SCRAPER`
+## Testing
+
+Before submitting a PR, please run your scraper.
+
+### With Docker
+
+```bash
+docker-compose run --rm scrapers pupa update YOUR_CITY_SCRAPER
+```
+
+### Without Docker
 
 ```bash
 export DATABASE_URL=postgresql:///opencivicdata

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - .:/src
     environment:
       DATABASE_URL: postgres://postgres:postgres@postgres/opencivicdata
+      DJANGO_SETTINGS_MODULE: pupa.settings
     command: pupa update lametro
 
   postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '2.4'
+
+services:
+  scrapers:
+    image: scrapers-us-municipal
+    container_name: scrapers-us-municipal
+    build: .
+    stdin_open: true
+    tty: true
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - .:/src
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@postgres/opencivicdata
+    command: pupa update lametro
+
+  postgres:
+    container_name: scrapers-us-municipal-postgres
+    image: postgis/postgis:latest
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    environment:
+      POSTGRES_DB: opencivicdata
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - scrapers-us-municipal-db-data:/var/lib/postgresql/data
+    ports:
+      - 32001:5432
+
+volumes:
+  scrapers-us-municipal-db-data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+pupa dbinit us
+
+exec "$@"


### PR DESCRIPTION
## Description

See title. I made these changes so scrapers can run with only a local installation of Docker and Docker Compose (i.e., users need not manage a local installation of Postgis). 

Closes #339, connects https://github.com/datamade/la-metro-councilmatic/issues/687.

### Testing instructions

I used this setup to test the changes to `pupa` in https://github.com/opencivicdata/pupa/pull/336:

- Mount your local pupa directory as a volume into the `scrapers` service:
    ```yml
        volumes:
          - .:/src
          - /abs/path/to/pupa:/pupa
    ```
- Spin up a scraper container and install the local version of pupa:
    ```bash
    docker-compose run --rm --name scrapers scrapers /bin/bash
    # inside container
    pip install -e pupa
    ```
- In a separate terminal window, execute a person scrape against the running scraper container:
    ```bash
    docker exec scrapers pupa update lametro people --rpm=0
    ```
- Confirm that the scrape runs without exception.