### PR TITLE
Metro: Scrape matters updated within a window, as well as matters related to events updated within a window

### DIFF
--- a/lametro/bills.py
+++ b/lametro/bills.py
@@ -9,6 +9,7 @@ from pupa.utils import _make_pseudo_id
 
 from legistar.bills import LegistarBillScraper, LegistarAPIBillScraper
 
+from .events import LametroEventScraper
 from .secrets import TOKEN
 
 class LametroBillScraper(LegistarAPIBillScraper, Scraper):
@@ -135,7 +136,36 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
 
                 yield bill_action, votes
 
-    def scrape(self, window=28, matter_ids=None) :
+    def matters(self, since_datetime=None):
+        '''
+        If a since_datetime is provided, scrape matters updated within the
+        window, as well as matters on agendas of events updated within the
+        window or scheduled to happen in the future, as they are likely to
+        change.
+        '''
+        if since_datetime:
+            seen = set()
+
+            for matter in super().matters(since_datetime=since_datetime):
+                seen.add(matter['MatterId'])
+                yield matter
+
+            event_scraper = LametroEventScraper(self.jurisdiction, self.datadir)
+            event_scraper.requests_per_minute = self.requests_per_minute
+            event_scraper.cache_write_only = self.cache_write_only
+
+            for api_event, _ in event_scraper.events(since_datetime=since_datetime):
+                for agenda_item in event_scraper.agenda(api_event):
+                    matter_id = agenda_item['EventItemMatterId']  # Can be null
+
+                    if matter_id and matter_id not in seen:
+                        yield self.matter(matter_id)
+                        seen.add(matter_id)
+
+        else:
+            yield from super().matters()
+
+    def scrape(self, window=28, matter_ids=None):
         '''By default, scrape board reports updated in the last 28 days.
         Optionally specify a larger or smaller window of time from which to
         scrape updates, or specific matters to scrape.


### PR DESCRIPTION
## Description

This PR overrides the `matters()` method of the Metro bills scraper as described in the PR title. This logic is similar to the default event scrape logic, and also mirrors our logic for refreshing the document cache (https://github.com/datamade/django-councilmatic/pull/267). 

### Notes

I made this change because Metro often updates board reports on upcoming agendas, but those updates do not toggle the corresponding updated at flag on the matter in the Legistar API, so the changes don't appear until the overnight bill scrape.

The number of extra calls is equal to `1 (call to retrieve windowed events) + number of events in the window (calls to retrieve agendas) + number of unseen matters (calls to retrieve the matters)`. Our regular windowed event scrapes (`window=0.05` and `window=1`) return ~20 events; the number of matters that have been updated will vary based on data entry, but updates that don't toggle the updated at flag seem rare. I would estimate that on average, this strategy would add 20-30 extra requests to a windowed bill scrape, or about 20-30 seconds based on the default request throttling of 1/second. This is reasonable for the Metro use case but could actually grow fairly large for broader scrapes. Because of this, and because this change is based on Metro's idiosyncratic data entry and update needs, I chose to make changes here rather than upstream.