### PR TITLE
Add another handled case, flexible logic for more than one attachment to minutes matter

### DIFF
--- a/lametro/events.py
+++ b/lametro/events.py
@@ -441,6 +441,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                 'June 24, 2021': 'LA SAFE MINUTES - June 24, 2021',
                 'December 2, 2021': 'Regular Board Meeting MINUTES - December 2, 2021',
                 'January 27, 2022': 'Regular Board Meeting MINUTES - January 27, 2022',
+                'February 24, 2022': 'MINUTES - February 24, 2022 RBM',
             }
 
             if date in handled_cases:
@@ -452,7 +453,21 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                 return attachment
 
             else:
-                raise ValueError("More than one attachment for the approved minutes matter")
+                try:
+                    attachment, = [
+                        each for each in attachments
+                        if 'minutes' in each['MatterAttachmentName'].lower()
+                    ]
+                except ValueError:
+                    raise ValueError(
+                        "More than one attachment for the approved minutes matter"
+                    )
+                else:
+                    msg = 'More than attachment for minutes matter {0}, using {1}'.format(
+                        matter['MatterId'], attachment['MatterAttachmentName']
+                    )
+                    self.info(msg)
+                    return attachment
 
 
 


### PR DESCRIPTION
## Description

This PR adds another handled case to multiple attachments to minutes matters, and, if there is more than one attachment moving forward, tries to grab the one with "minutes" in its title. 

Per Metro, the naming convention isn't guaranteed to be specific, but looking for "minutes" is a good starting point https://github.com/datamade/la-metro-councilmatic/issues/742#issuecomment-1048278789.

### Testing instructions

_Already done_

- Run a full event scrape and confirm it succeeds.