### PR TITLE
Rename 'Notice' to 'Meeting Extra1'

### DIFF
--- a/chicago/events.py
+++ b/chicago/events.py
@@ -54,7 +54,7 @@ class ChicagoEventsScraper(LegistarAPIEventScraper, Scraper) :
                                  type="recording",
                                  media_type = 'text/html')
             self.addDocs(e, web_event, 'Published agenda')
-            self.addDocs(e, web_event, 'Notice')
+            self.addDocs(e, web_event, 'Meeting Extra1')
             self.addDocs(e, web_event, 'Published summary')
             if 'Captions' in web_event:
                 self.addDocs(e, web_event, 'Captions')


### PR DESCRIPTION
## Description

This PR addresses an KeyError in the Chicago scraper caused by a change to event pages. What used to be the 'Notice' section of the event details is now called 'Meeting Extra1'.

<img width="1046" alt="Screen Shot 2022-04-28 at 11 15 20 AM" src="https://user-images.githubusercontent.com/36973363/165785881-59f6281a-7229-452b-9206-b4827e82a0a9.png">

## Testing Instructions

- Verify that the Chicago scraper no longer raises a KeyError while running