### PR TITLE
Add approved_minutes field to event extras

### DIFF
--- a/lametro/events.py
+++ b/lametro/events.py
@@ -318,6 +318,9 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                                    url=approved_minutes['MatterAttachmentHyperlink'],
                                    media_type="application/pdf",
                                    date=self.to_utc_timestamp(approved_minutes['MatterAttachmentLastModifiedUtc']).date())
+                    e.extras['approved_minutes'] = True
+                else:
+                    e.extras['approved_minutes'] = False
 
             for audio in event['audio']:
                 try:


### PR DESCRIPTION
## Overview

This PR adds an `approved_minutes` boolean to events returned by the LA Metro scraper.

## Testing instructions

* Run the scraper and verify that new events contain an `approved_minutes` entry in their extras