### PR TITLE
Add District 7 interim post

### DIFF
--- a/lametro/__init__.py
+++ b/lametro/__init__.py
@@ -48,6 +48,10 @@ class Lametro(Jurisdiction):
                      'Nonvoting Board Member',
                      division_id='ocd-division/country:us/state:ca')
 
+        org.add_post('District 7 Director (Interim), California Department of Transportation (Caltrans), Appointee of the Governor of California',
+                     'Nonvoting Board Member',
+                     division_id='ocd-division/country:us/state:ca')
+
         org.add_post('Appointee of Los Angeles County City Selection Committee, North County/San Fernando Valley sector',
                      'Board Member',
                      division_id='ocd-division/country:us/state:ca/county:los_angeles/la_metro_sector:north_county_san_fernando_valley')


### PR DESCRIPTION
## Overview

This PR adds in a new post for the Interim District 7 Director for LA Metro.

Handles #361 


## Testing Instructions

* Run the people scraper with `docker-compose run --rm scrapers pupa update lametro people`
* Verify that all members are successfully loaded into the db