### PR TITLE
Handle another event with more than one minutes file

### DIFF
--- a/lametro/events.py
+++ b/lametro/events.py
@@ -446,6 +446,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                 'December 2, 2021': 'Regular Board Meeting MINUTES - December 2, 2021',
                 'January 27, 2022': 'Regular Board Meeting MINUTES - January 27, 2022',
                 'February 24, 2022': 'MINUTES - February 24, 2022 RBM',
+                'June 23, 2022': 'Regular Board Meeting MINUTES - June 23, 2022'
             }
 
             if date in handled_cases:


### PR DESCRIPTION
## Overview

See title.

## Testing Instructions

* Run the scraper (I used `docker-compose run --rm scrapers pupa update lametro events window=75 --rpm=0`) and verify that it doesn't raise any errors