### PR TITLE
Catch UnmatchedEventErrors in lametro scrapes

### DIFF
--- a/lametro/events.py
+++ b/lametro/events.py
@@ -184,9 +184,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
             assert not spanish_events  # These should all be merged with an English event.
         except AssertionError:
             unpaired_events = [event for event, _ in spanish_events.values()]
-            raise UnmatchedEventError(unpaired_events)
-        except UnmatchedEventError as e:
-            LOGGER.critical(e)
+            LOGGER.critical(unpaired_events)
 
         return english_events
 


### PR DESCRIPTION
## Overview

This PR modifies the behavior of LA Metro scrapes to log `UnmatchedEventError`s and continue scraping rather than failing.

## Testing Instructions

I tested by manually adding lines to raise an `UnmatchedEventError` in both `LametroEventScraper.api_events()` and `LametroEventScraper._merge_events()`.