### PR TITLE
Log multiple minutes errors in LA metro scraper

### DIFF
--- a/lametro/events.py
+++ b/lametro/events.py
@@ -25,6 +25,17 @@ class UnmatchedEventError(Exception):
 
         super().__init__(message)
 
+
+class MultipleMinutesError(Exception):
+    def __init__(self, event, minutes):
+        message = f"Event {event} has more than one attachment for the \
+approved minutes matter:\n"
+        for file in minutes:
+            message += f"{file}\n"
+
+        super().__init__(message)
+
+
 class LametroEventScraper(LegistarAPIEventScraper, Scraper):
     BASE_URL = 'http://webapi.legistar.com/v1/metro'
     WEB_URL = 'https://metro.legistar.com/'
@@ -464,7 +475,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                         if 'minutes' in each['MatterAttachmentName'].lower()
                     ]
                 except ValueError:
-                    raise ValueError(
+                    LOGGER.critical(
                         "More than one attachment for the approved minutes matter"
                     )
                 else:

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -26,16 +26,6 @@ class UnmatchedEventError(Exception):
         super().__init__(message)
 
 
-class MultipleMinutesError(Exception):
-    def __init__(self, event, minutes):
-        message = f"Event {event} has more than one attachment for the \
-approved minutes matter:\n"
-        for file in minutes:
-            message += f"{file}\n"
-
-        super().__init__(message)
-
-
 class LametroEventScraper(LegistarAPIEventScraper, Scraper):
     BASE_URL = 'http://webapi.legistar.com/v1/metro'
     WEB_URL = 'https://metro.legistar.com/'


### PR DESCRIPTION
## Overview

This PR changes the LA Metro scraper's behavior to log when events have multiple minutes files instead of raising an exception.