### PR TITLE
Skip temporary bills for LA Metro

### DIFF
--- a/lametro/bills.py
+++ b/lametro/bills.py
@@ -198,6 +198,10 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
             if matter['MatterFile'] == '2017-0447':
                 continue
 
+            bill_is_temporary = matter['MatterFile'].lower().startswith('tmp')
+            if bill_is_temporary:
+                continue
+
             matter_id = matter['MatterId']
 
             date = matter['MatterIntroDate']


### PR DESCRIPTION
## Overview

See title. The "MatterFile" property of temporary bills in Metro's Legistar instance begin with "TMP."