### PR TITLE
Metro: Remove (Interim) suffix from person name

### DIFF
--- a/lametro/people.py
+++ b/lametro/people.py
@@ -78,6 +78,7 @@ class LametroPersonScraper(LegistarAPIPersonScraper, Scraper):
 
         members = {}
         for member, offices in terms.items():
+            member = member.replace(' (Interim)', '')
             p = Person(member)
 
             for term in offices:
@@ -122,8 +123,6 @@ class LametroPersonScraper(LegistarAPIPersonScraper, Scraper):
             if member == 'Hilda L. Solis':
                 # Given/family name does not contain middle initial.
                 assert p.given_name == 'Hilda' and p.family_name == 'Solis'
-            elif member == 'Gloria Roberts (Interim)':
-                assert p.given_name == 'Gloria' and p.family_name == 'Roberts'
             else:
                 assert member == ' '.join([p.given_name, p.family_name])
 


### PR DESCRIPTION
## Description

See title.

This is necessary to prevent duplicate people from being created if a suffix is added later.

Connects https://github.com/datamade/la-metro-councilmatic/issues/920