### PR TITLE
Handle unnamed board correspondences

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,47 @@
+name: Run tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-20.04
+    services:
+      postgres:
+        image: postgis/postgis:11-3.3
+        env:
+          POSTGRES_DB: lametro
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    steps:
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install gdal-bin libxml2-dev
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v2
+      with:
+        # Semantic version range syntax or exact version of a Python version
+        python-version: '3.6'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install "setuptools-scm<7.0"
+        pip install -r requirements.txt
+    - name: Test with pytest
+      run: |
+        echo "TOKEN='faketoken'" > lametro/secrets.py 
+        pytest -sv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 
   postgres:
     container_name: scrapers-us-municipal-postgres
-    image: postgis/postgis:latest
+    image: postgis/postgis:11-3.3
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s

--- a/lametro/bills.py
+++ b/lametro/bills.py
@@ -203,6 +203,10 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
             title = matter['MatterTitle']
             identifier = matter['MatterFile']
 
+            is_board_correspondence = matter['MatterTypeName'] in {'Board Box', 'Board Correspondence'}
+            if is_board_correspondence and not title:
+                title = f"Board Correspondence {identifier}"
+
             if not all((date, title, identifier)) :
                 continue
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ pupa==0.10.1
 https://github.com/opencivicdata/python-legistar-scraper/zipball/master
 lxml
 sh 
-pytest==4.2.0
+pytest==5.4.3
 pytest-mock==1.10.1
 requests-mock==1.5.2

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '2.4'
+
+services:
+  scrapers:
+    restart: "no"
+    command: pytest -sxv

--- a/tests/lametro/conftest.py
+++ b/tests/lametro/conftest.py
@@ -39,7 +39,7 @@ def api_event():
              'SAPEventId': 1535, 
              'EventAgendaStatusName': 'Final',
              'SAPEventGuid': '8962CCBC-5E42-4B3B-91DA-6178D507079C',
-             'start': datetime.datetime(2019, 2, 28, 9, 30),
+             'start': datetime.datetime(2019, 2, 28, 9, 30, tzinfo=datetime.timezone.utc),
              'EventInSiteURL': '', 
              'EventTime': '9:30 AM'}
 
@@ -54,6 +54,7 @@ def web_event():
     web_event = {'Meeting Details': {'label': 'Meeting\xa0details', 'url': ''}, 
                  'Meeting Time': '9:30 AM', 
                  'eComment': 'Not\xa0available', 
+                 'Published minutes': 'Not\xa0available', 
                  'Name': {'label': 'Board of Directors - Regular Board Meeting', 'url': ''}, 
                  'Meeting Date': '2/28/2019', 
                  'Audio': {'label': 'Audio', 'url': ''},

--- a/tests/lametro/test_events.py
+++ b/tests/lametro/test_events.py
@@ -5,7 +5,7 @@ import re
 
 from pupa.scrape.event import Event
 
-from lametro.events import LAMetroAPIEvent
+from lametro.events import LAMetroAPIEvent, LAMetroWebEvent
 
 
 @pytest.mark.parametrize('api_status_name,scraper_assigned_status', [
@@ -30,7 +30,7 @@ def test_status_assignment(event_scraper,
 
         api_event['EventAgendaStatusName'] = api_status_name
 
-        mocker.patch('lametro.LametroEventScraper._merge_events', return_value=[(api_event, web_event)])
+        mocker.patch('lametro.LametroEventScraper._merge_events', return_value=[(api_event, LAMetroWebEvent(web_event))])
 
         for event in event_scraper.scrape():
             assert event.status == scraper_assigned_status
@@ -60,7 +60,7 @@ def test_sequence_duplicate_error(event_scraper,
         event_agenda_item_b = event_agenda_item.copy()
         event_agenda_item_b['EventItemAgendaSequence'] = item_sequence
 
-        mocker.patch('lametro.LametroEventScraper._merge_events', return_value=[(api_event, web_event)])
+        mocker.patch('lametro.LametroEventScraper._merge_events', return_value=[(api_event, LAMetroWebEvent(web_event))])
         mocker.patch('lametro.LametroEventScraper.agenda', return_value=[event_agenda_item, event_agenda_item_b])
 
         if should_error:


### PR DESCRIPTION
## Overview

This PR adds logic to handle unnamed board correspondences, as outlined in [this LA Metro councilmatic issue](https://github.com/datamade/la-metro-councilmatic/issues/904). 

## Tests

This PR also resurrects scraper tests. I've included a few updates to existing tests to get them passing and added a new one to test this board correspondence logic.