### PR TITLE
add exception for handling vacant committee members

### DIFF
--- a/chicago/people.py
+++ b/chicago/people.py
@@ -136,15 +136,23 @@ class ChicagoPersonScraper(ElmsAPI, Scraper):
                     person_name = "Rodriguez Sanchez, Rossana"
                 elif person_name in {"Willie B., Cochran", "Willie B. Cochran"}:
                     person_name = "Cochran, Willie B."
-                person = alders[person_name]
-                person.add_membership(
-                    org,
-                    role=term["memberType"],
-                    start_date=datetime.datetime.fromisoformat(
-                        term["startDate"]
-                    ).date(),
-                    end_date=datetime.datetime.fromisoformat(term["endDate"]).date(),
-                )
+                
+                try:
+                    person = alders[person_name]
+                    person.add_membership(
+                        org,
+                        role=term["memberType"],
+                        start_date=datetime.datetime.fromisoformat(
+                            term["startDate"]
+                        ).date(),
+                        end_date=datetime.datetime.fromisoformat(term["endDate"]).date(),
+                    )
+                except KeyError as error:
+                    if "vacant" in person_name.lower():
+                        continue
+                    
+                    print("Problem adding to Committee:")
+                    print(error)
 
             yield org
 

--- a/chicago/people.py
+++ b/chicago/people.py
@@ -139,6 +139,11 @@ class ChicagoPersonScraper(ElmsAPI, Scraper):
                 
                 try:
                     person = alders[person_name]
+                except KeyError as error:
+                    if "vacant" in person_name.lower():
+                        continue
+                    self.warning("Problem adding to Committee:", person_name)
+                else:
                     person.add_membership(
                         org,
                         role=term["memberType"],
@@ -147,12 +152,7 @@ class ChicagoPersonScraper(ElmsAPI, Scraper):
                         ).date(),
                         end_date=datetime.datetime.fromisoformat(term["endDate"]).date(),
                     )
-                except KeyError as error:
-                    if "vacant" in person_name.lower():
-                        continue
-                    
-                    print("Problem adding to Committee:")
-                    print(error)
+                
 
             yield org
 


### PR DESCRIPTION
Chicago: handling case where committee member is vacant, logging if there is a `KeyError` otherwise